### PR TITLE
Fix AssistantPage build errors, add transactions page-size setting, and improve collapsed topbar

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -408,6 +408,30 @@ body {
   color: var(--color-text-tertiary);
 }
 
+.topbar-brand-copy {
+  min-width: 0;
+}
+
+.topbar-brand-copy h1,
+.topbar-brand-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.layout-shell.sidebar-is-collapsed .workspace-topbar {
+  padding-left: var(--space-4);
+}
+
+.layout-shell.sidebar-is-collapsed .topbar-brand-copy.compact span {
+  display: none;
+}
+
+.layout-shell.sidebar-is-collapsed .logo-circle {
+  width: 32px;
+  height: 32px;
+}
+
 .content {
   max-width: var(--content-max-width);
   margin: 0 auto;
@@ -1161,6 +1185,40 @@ tr:hover td {
   font-size: var(--font-sm);
   color: var(--color-text-secondary);
   padding: 4px;
+}
+
+.transaction-pagination {
+  gap: var(--space-2);
+}
+
+.transaction-pagination-controls {
+  gap: var(--space-2);
+}
+
+.transaction-page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.transaction-page-size select {
+  min-height: 32px;
+  padding: 4px 8px;
+  width: auto;
+}
+
+@media (max-width: 768px) {
+  .transaction-pagination,
+  .transaction-pagination-controls {
+    width: 100%;
+  }
+
+  .transaction-pagination-controls {
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
 }
 
 small.mono {

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -71,6 +71,8 @@ interface TransactionTableProps {
   filteredTotal: number;
   page: number;
   pages: number;
+  pageSize: number;
+  pageSizeOptions: number[];
   loading: boolean;
   errorMessage?: string;
   hasFilters: boolean;
@@ -85,6 +87,7 @@ interface TransactionTableProps {
   onClearFilters: () => void;
   onPrevPage: () => void;
   onNextPage: () => void;
+  onPageSizeChange: (size: number) => void;
   onOpenDetail: (id: string) => void;
   onDelete: (id: string) => void;
   onDeleteSelected: () => void;
@@ -108,6 +111,8 @@ export function TransactionTable({
   filteredTotal,
   page,
   pages,
+  pageSize,
+  pageSizeOptions,
   loading,
   errorMessage,
   hasFilters,
@@ -122,6 +127,7 @@ export function TransactionTable({
   onClearFilters,
   onPrevPage,
   onNextPage,
+  onPageSizeChange,
   onOpenDetail,
   onDelete,
   onDeleteSelected,
@@ -606,11 +612,28 @@ export function TransactionTable({
               )
             : null}
 
-          <div className="row" style={{ marginTop: 12, justifyContent: 'space-between' }}>
+          <div
+            className="row transaction-pagination"
+            style={{ marginTop: 12, justifyContent: 'space-between' }}
+          >
             <small style={{ color: 'var(--color-text-secondary)' }}>
               当前 {filteredTotal} 条 / 全部 {total} 条
             </small>
-            <div className="row">
+            <div className="row transaction-pagination-controls">
+              <label className="transaction-page-size">
+                每页
+                <select
+                  aria-label="每页显示条数"
+                  value={pageSize}
+                  onChange={(event) => onPageSizeChange(Number(event.target.value))}
+                >
+                  {pageSizeOptions.map((size) => (
+                    <option key={`page-size-${size}`} value={size}>
+                      {size} 条
+                    </option>
+                  ))}
+                </select>
+              </label>
               <button type="button" disabled={page === 1} onClick={onPrevPage}>
                 上一页
               </button>

--- a/src/pages/assistant/AssistantPage.tsx
+++ b/src/pages/assistant/AssistantPage.tsx
@@ -153,6 +153,7 @@ const QUICK_BILL_TEMPLATES = [
 ];
 
 const QUICK_AMOUNT_ACTIONS = [10, 20, 50, 100];
+const CHAT_HISTORY_CACHE_KEY = 'ledgerflow.assistant.chatHistory';
 
 function toMonthKey(date: string) {
   return date.slice(0, 7);
@@ -232,7 +233,6 @@ export function AssistantPage() {
   });
 
   const [modelOpen, setModelOpen] = useState(false);
-  const [mode, setMode] = useState<AssistantMode>('assistant');
   const [presetQuestions, setPresetQuestions] = useState<PresetQuestion[]>([]);
   const [loadingPresets, setLoadingPresets] = useState(false);
   const [chatHistory, setChatHistory] = useState<ChatHistoryItem[]>(() => {
@@ -252,7 +252,6 @@ export function AssistantPage() {
       return [];
     }
   });
-  const [chatHistory, setChatHistory] = useState<ChatHistoryItem[]>([]);
   const lastAssistantRef = useRef('');
   const messageEndRef = useRef<HTMLDivElement | null>(null);
 
@@ -319,20 +318,14 @@ export function AssistantPage() {
     const usageText = wb.lastUsage
       ? `Token 消耗：输入 ${wb.lastUsage.promptTokens} / 输出 ${wb.lastUsage.completionTokens} / 总计 ${wb.lastUsage.totalTokens}`
       : undefined;
-    setChatHistories((prev) => ({
+    setChatHistory((prev) => [
       ...prev,
-      [mode]: [
-        ...(prev[mode] || []),
-        { id: `${Date.now()}-assistant`, role: 'assistant', text: wb.rawContent, usageText }
-      ]
-    }));
-  }, [mode, wb.lastUsage, wb.rawContent]);
+      { id: `${Date.now()}-assistant`, role: 'assistant', text: wb.rawContent, usageText }
+    ]);
+  }, [wb.lastUsage, wb.rawContent]);
 
   const removeMessage = (id: string) =>
-    setChatHistories((prev) => ({
-      ...prev,
-      [mode]: (prev[mode] || []).filter((item) => item.id !== id)
-    }));
+    setChatHistory((prev) => prev.filter((item) => item.id !== id));
 
   const retryMessage = (index: number) => {
     const previousUser = [...chatHistory]

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -26,7 +26,9 @@ import {
 import { Category } from '../../entities/category/types';
 import { TransactionSource } from '../../entities/transaction/types';
 
-const PAGE_SIZE = 8;
+const DEFAULT_PAGE_SIZE = 8;
+const PAGE_SIZE_OPTIONS = [8, 20, 50, 100] as const;
+const TX_PAGE_SIZE_KEY = 'ledgerflow.transactions.pageSize';
 type BillSource = 'wechat' | 'alipay';
 
 const DEFAULT_QUICK_FILTERS: TransactionQuickFilters = {
@@ -100,6 +102,19 @@ function restoreRecordState<K extends string>(
     return next;
   } catch {
     return defaults;
+  }
+}
+
+function restorePageSize(): number {
+  try {
+    const raw = window.localStorage.getItem(TX_PAGE_SIZE_KEY);
+    if (!raw) return DEFAULT_PAGE_SIZE;
+    const parsed = Number(raw);
+    return PAGE_SIZE_OPTIONS.includes(parsed as (typeof PAGE_SIZE_OPTIONS)[number])
+      ? parsed
+      : DEFAULT_PAGE_SIZE;
+  } catch {
+    return DEFAULT_PAGE_SIZE;
   }
 }
 
@@ -269,6 +284,8 @@ export function TransactionsPage() {
   >(() =>
     restoreRecordState<TransactionDetailSectionKey>(TX_DETAIL_SECTIONS_KEY, DEFAULT_DETAIL_SECTIONS)
   );
+  // 页大小允许用户按账单密度自由切换，长列表下减少翻页成本。
+  const [pageSize, setPageSize] = useState<number>(() => restorePageSize());
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const importSourceRef = useRef<BillSource | null>(null);
@@ -323,6 +340,10 @@ export function TransactionsPage() {
   useEffect(() => {
     window.localStorage.setItem(TX_DETAIL_SECTIONS_KEY, JSON.stringify(visibleDetailSections));
   }, [visibleDetailSections]);
+
+  useEffect(() => {
+    window.localStorage.setItem(TX_PAGE_SIZE_KEY, String(pageSize));
+  }, [pageSize]);
 
   useEffect(() => {
     const highlight = searchParams.get('highlight') ?? '';
@@ -457,7 +478,7 @@ export function TransactionsPage() {
     return rows;
   }, [quickFilteredRows, sortDirection, sortKey]);
 
-  const pages = Math.max(1, Math.ceil(sortedRows.length / PAGE_SIZE));
+  const pages = Math.max(1, Math.ceil(sortedRows.length / pageSize));
   const page = Math.min(filters.page, pages);
 
   useEffect(() => {
@@ -466,7 +487,7 @@ export function TransactionsPage() {
     }
   }, [filters.page, pages, setPage]);
 
-  const viewRows = sortedRows.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const viewRows = sortedRows.slice((page - 1) * pageSize, page * pageSize);
 
   const selected = useMemo(
     () => transactions.find((item) => item.id === selectedId) ?? null,
@@ -539,7 +560,7 @@ export function TransactionsPage() {
       const insertedIds = normalizedParsed.map((item) => addTransaction(item));
       const newestId = insertedIds[insertedIds.length - 1];
       const expectedIndex = Math.max(0, filteredRows.length + normalizedParsed.length - 1);
-      const expectedPage = Math.floor(expectedIndex / PAGE_SIZE) + 1;
+      const expectedPage = Math.floor(expectedIndex / pageSize) + 1;
       setPage(expectedPage);
       const message = `导入成功：新增 ${normalizedParsed.length} 条记录。`;
       showToast(message, 'success');
@@ -804,6 +825,8 @@ export function TransactionsPage() {
       />
 
       <TransactionTable
+        pageSize={pageSize}
+        pageSizeOptions={[...PAGE_SIZE_OPTIONS]}
         rows={viewRows}
         total={transactions.length}
         filteredTotal={sortedRows.length}
@@ -822,6 +845,11 @@ export function TransactionsPage() {
         onQuickFilterChange={handleQuickFilterChange}
         onPrevPage={() => setPage(Math.max(1, page - 1))}
         onNextPage={() => setPage(Math.min(pages, page + 1))}
+        onPageSizeChange={(size) => {
+          // 切换页大小后重置到第一页，避免超页码导致用户误解“数据丢失”。
+          setPageSize(size);
+          setPage(1);
+        }}
         onOpenDetail={setSelectedId}
         selectedIds={selectedIds}
         canSelectAllOnPage={canSelectAllOnPage}

--- a/src/widgets/layout/AppLayout.tsx
+++ b/src/widgets/layout/AppLayout.tsx
@@ -167,7 +167,7 @@ export function AppLayout() {
 
   return (
     <div
-      className="layout-shell"
+      className={`layout-shell ${collapsed ? 'sidebar-is-collapsed' : ''}`.trim()}
       style={{
         ['--sidebar-width' as string]: `${collapsed ? SIDEBAR_COLLAPSED_WIDTH : sidebarWidth}px`
       }}
@@ -276,7 +276,7 @@ export function AppLayout() {
               </div>
             ) : null}
 
-            <div>
+            <div className={`topbar-brand-copy ${collapsed ? 'compact' : ''}`.trim()}>
               <h1>LedgerFlow</h1>
               <span>v{APP_VERSION} · 智能记账工作台</span>
             </div>


### PR DESCRIPTION
### Motivation
- Resolve TypeScript build failures in the assistant page that caused Docker `npm run build` to fail.  
- Make the transactions list more usable on long pages by allowing users to change how many rows are shown per page.  
- Improve the topbar/logo appearance and avoid visual clipping when the sidebar is collapsed.

### Description
- Fixed `AssistantPage` TypeScript issues by removing duplicated `mode`/`chatHistory` state declarations, adding the `CHAT_HISTORY_CACHE_KEY` constant, and replacing incorrect `setChatHistories` usages with `setChatHistory` while preserving session-storage restore behavior.  
- Enhanced transactions pagination by introducing `DEFAULT_PAGE_SIZE`, `PAGE_SIZE_OPTIONS`, and `TX_PAGE_SIZE_KEY`, adding a `pageSize` state persisted to `localStorage`, switching pagination math and view slicing to use dynamic `pageSize`, and propagating `pageSize` and `onPageSizeChange` into `TransactionTable` with a new dropdown control.  
- Improved collapsed topbar layout by adding the `sidebar-is-collapsed` class, wrapping title copy in `topbar-brand-copy`, and adding CSS to ellipsize/hide the subtitle and shrink the avatar when collapsed; also added styles for the new pagination control and mobile behavior.

### Testing
- Ran `npm run build` (TypeScript + Vite) and the production build completed successfully.  
- Ran the test suite with `npm run test -- --run` and all automated tests passed (`21` tests across `11` test files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f060b0e048327a7672f324aae27f9)