### PR TITLE
优化 AI 记账展示、移除快捷建单并修复 WebDAV Basic Auth 编码问题

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -2741,13 +2741,13 @@ small.mono {
   border-radius: 2px;
 }
 
-.chat-json-toolbar {
+.chat-preview-toolbar {
   display: flex;
   gap: var(--space-2);
   margin-bottom: var(--space-3);
 }
 
-.chat-json-toolbar > button {
+.chat-preview-toolbar > button {
   font-size: var(--font-xs);
   padding: 4px 10px;
 }
@@ -2871,35 +2871,6 @@ small.mono {
   transform: translateY(-1px);
   border-color: var(--color-primary-border);
   box-shadow: var(--shadow-xs);
-}
-
-.chat-quick-amount-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-  padding: var(--space-2) var(--space-5);
-  border-bottom: 1px solid var(--color-divider);
-  background: color-mix(in srgb, var(--color-primary-bg) 45%, transparent);
-}
-
-.chat-quick-amount-row > span {
-  font-size: var(--font-xs);
-  color: var(--color-text-secondary);
-}
-
-.chat-quick-amount-row > button {
-  font-size: var(--font-xs);
-  border-radius: var(--radius-full);
-  padding: 4px 10px;
-  border: 1px solid var(--color-border);
-  color: var(--color-text-secondary);
-  background: var(--color-bg-elevated);
-}
-
-.chat-quick-amount-row > button:hover:not(:disabled) {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
 }
 
 /* ---------- Input Bar ---------- */
@@ -5203,9 +5174,10 @@ small.mono {
 
 .chat-disclaimer {
   margin: 0;
-  padding: 6px var(--space-5) 0;
+  padding: 8px var(--space-5) 4px;
   font-size: 11px;
   color: var(--color-text-placeholder);
+  text-align: center;
 }
 
 .chat-dup-alert {

--- a/src/features/assistant/ui/BillPreviewCard.tsx
+++ b/src/features/assistant/ui/BillPreviewCard.tsx
@@ -1,53 +1,30 @@
-import { useMemo, useState } from 'react';
 import type { DraftBillEntry } from '../workbench/workbenchTypes';
 
 interface BillPreviewCardProps {
-  payload: unknown;
   entries: DraftBillEntry[];
   duplicateCount: number;
   onCheckDuplicates: () => number;
-  onSave: () => void;
+  onSave: () => boolean;
   onSaved?: () => void;
 }
 
 export function BillPreviewCard({
-  payload,
   entries,
   duplicateCount,
   onCheckDuplicates,
   onSave,
   onSaved
 }: BillPreviewCardProps) {
-  const [collapsed, setCollapsed] = useState(false);
-  const [copied, setCopied] = useState(false);
-
-  const jsonText = useMemo(() => JSON.stringify(payload, null, 2), [payload]);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(jsonText);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1400);
-    } catch {
-      setCopied(false);
-    }
-  };
-
   const handleSave = () => {
-    onSave();
-    onSaved?.();
+    if (onSave()) {
+      onSaved?.();
+    }
   };
 
   return (
     <div className="chat-bill-preview">
       <h3>✅ AI 识别账单</h3>
-      <div className="chat-json-toolbar">
-        <button type="button" onClick={handleCopy}>
-          {copied ? '已复制' : '复制 JSON'}
-        </button>
-        <button type="button" onClick={() => setCollapsed((v) => !v)}>
-          {collapsed ? '展开' : '折叠'}
-        </button>
+      <div className="chat-preview-toolbar">
         <button type="button" onClick={onCheckDuplicates}>
           检测重复账单
         </button>
@@ -72,8 +49,6 @@ export function BillPreviewCard({
           </article>
         ))}
       </div>
-
-      {!collapsed ? <pre>{jsonText}</pre> : null}
       <button type="button" className="primary" onClick={handleSave}>
         💾 一键保存到账本
       </button>

--- a/src/features/assistant/workbench/useAssistantWorkbench.ts
+++ b/src/features/assistant/workbench/useAssistantWorkbench.ts
@@ -307,51 +307,67 @@ export function useAssistantWorkbench(input: UseAssistantWorkbenchInput) {
   /** 将当前勾选且校验通过的草稿条目写入账本。 */
   const saveSelected = () => {
     const rows = entries.filter((item) => item.selected && item.issues.length === 0);
-    if (rows.length === 0)
-      return setToast({ visible: true, variant: 'warning', message: '没有可保存的有效账单' });
+    if (rows.length === 0) {
+      setToast({ visible: true, variant: 'warning', message: '没有可保存的有效账单' });
+      return false;
+    }
     setStatus('saving');
     addLog({ action: 'assistant.save', status: 'pending', message: `准备保存 ${rows.length} 条` });
-    const duplicateRows = rows.filter((item) => item.duplicateTxId);
-    let overwriteDuplicates = false;
-    if (duplicateRows.length > 0) {
-      overwriteDuplicates = window.confirm(
-        `检测到 ${duplicateRows.length} 条疑似重复账单。
+
+    try {
+      const duplicateRows = rows.filter((item) => item.duplicateTxId);
+      let overwriteDuplicates = false;
+      if (duplicateRows.length > 0) {
+        overwriteDuplicates = window.confirm(
+          `检测到 ${duplicateRows.length} 条疑似重复账单。
 点击“确定”将覆盖旧账单；点击“取消”将保留旧账单并新增。`
-      );
-    }
-
-    rows.forEach((item) => {
-      const type = item.type === 'unknown' ? 'expense' : item.type;
-      const category = item.category.trim() || inferCategoryFromText(type, item.note || '');
-      // 来源优先级：模型显式 sourceHint > 文本推断，保证账单账户归属更稳定。
-      const source =
-        item.sourceHint === 'wechat' || item.sourceHint === 'alipay'
-          ? item.sourceHint
-          : inferSourceFromText(`${item.note} ${(item.tags || []).join(' ')}`);
-
-      const payload = {
-        type,
-        amount: normalizeMoney(item.amount),
-        date: normalizeEntryDate(item.date),
-        note: item.note || 'AI 导入账单',
-        tags: inferTags(type, item.note, category, item.tags || ['AI识别']),
-        categoryId: ensureCategoryId(category, input.categories, input.addCategory),
-        accountId: resolveAccountId(item.account, input.accounts, { source, type }),
-        orderNo: item.orderNo?.trim() || undefined,
-        merchantOrderNo: item.merchantOrderNo?.trim() || undefined,
-        source
-      };
-
-      if (overwriteDuplicates && item.duplicateTxId) {
-        input.updateTransaction(item.duplicateTxId, payload);
-      } else {
-        input.addTransaction(payload);
+        );
       }
-    });
-    setEntries([]);
-    setStatus('saved');
-    setToast({ visible: true, variant: 'success', message: `已保存 ${rows.length} 条账单` });
-    addLog({ action: 'assistant.save', status: 'success', message: `保存完成 ${rows.length} 条` });
+
+      rows.forEach((item) => {
+        const type = item.type === 'unknown' ? 'expense' : item.type;
+        const category = item.category.trim() || inferCategoryFromText(type, item.note || '');
+        // 来源优先级：模型显式 sourceHint > 文本推断，保证账单账户归属更稳定。
+        const source =
+          item.sourceHint === 'wechat' || item.sourceHint === 'alipay'
+            ? item.sourceHint
+            : inferSourceFromText(`${item.note} ${(item.tags || []).join(' ')}`);
+
+        const payload = {
+          type,
+          amount: normalizeMoney(item.amount),
+          date: normalizeEntryDate(item.date),
+          note: item.note || 'AI 导入账单',
+          tags: inferTags(type, item.note, category, item.tags || ['AI识别']),
+          categoryId: ensureCategoryId(category, input.categories, input.addCategory),
+          accountId: resolveAccountId(item.account, input.accounts, { source, type }),
+          orderNo: item.orderNo?.trim() || undefined,
+          merchantOrderNo: item.merchantOrderNo?.trim() || undefined,
+          source
+        };
+
+        if (overwriteDuplicates && item.duplicateTxId) {
+          input.updateTransaction(item.duplicateTxId, payload);
+        } else {
+          input.addTransaction(payload);
+        }
+      });
+      setEntries([]);
+      setStatus('saved');
+      setToast({ visible: true, variant: 'success', message: `已保存 ${rows.length} 条账单` });
+      addLog({
+        action: 'assistant.save',
+        status: 'success',
+        message: `保存完成 ${rows.length} 条`
+      });
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '保存失败，请重试';
+      setStatus('error');
+      setToast({ visible: true, variant: 'error', message });
+      addLog({ action: 'assistant.save', status: 'error', message });
+      return false;
+    }
   };
 
   const resetWorkbench = () => {

--- a/src/pages/assistant/AssistantPage.tsx
+++ b/src/pages/assistant/AssistantPage.tsx
@@ -152,7 +152,6 @@ const QUICK_BILL_TEMPLATES = [
   { label: '💼 工资入账', prompt: '本月工资到账 12000 元，入账银行卡' }
 ];
 
-const QUICK_AMOUNT_ACTIONS = [10, 20, 50, 100];
 const CHAT_HISTORY_CACHE_KEYS: Record<AssistantMode, string> = {
   bookkeeping: 'ledgerflow.assistant.chatHistory.bookkeeping',
   assistant: 'ledgerflow.assistant.chatHistory.assistant'
@@ -273,23 +272,6 @@ export function AssistantPage() {
   const duplicateEntriesCount = useMemo(
     () => wb.entries.filter((item) => item.duplicateTxId).length,
     [wb.entries]
-  );
-
-  const previewPayload = useMemo(
-    () => ({
-      transactions: selectedValidEntries.map((item) => ({
-        type: item.type,
-        amount: item.amount,
-        date: item.date,
-        note: item.note,
-        category: item.category,
-        account: item.account,
-        tags: item.tags,
-        orderNo: item.orderNo,
-        merchantOrderNo: item.merchantOrderNo
-      }))
-    }),
-    [selectedValidEntries]
   );
 
   // 每次状态或消息变化后，自动将视图滚动到底部，保持聊天体验。
@@ -617,24 +599,18 @@ export function AssistantPage() {
             </article>
           ))}
 
-          {wb.rawReasoning ? (
+          {selectedValidEntries.length > 0 ? (
             <article className="chat-msg">
-              <div className="chat-msg-avatar">🧠</div>
+              <div className="chat-msg-avatar">✅</div>
               <div className="chat-msg-body">
-                <details className="chat-thinking-box" open>
-                  <summary>查看推理摘要</summary>
-                  <div className="chat-thinking-scroll">{wb.rawReasoning}</div>
-                </details>
-                {selectedValidEntries.length > 0 ? (
-                  <BillPreviewCard
-                    payload={previewPayload}
-                    entries={wb.entries}
-                    duplicateCount={duplicateEntriesCount}
-                    onCheckDuplicates={wb.checkDuplicates}
-                    onSave={wb.saveSelected}
-                    onSaved={() => wb.setToastState('账单已写入账本', 'success')}
-                  />
-                ) : null}
+                <div className="chat-msg-header">识别结果</div>
+                <BillPreviewCard
+                  entries={wb.entries}
+                  duplicateCount={duplicateEntriesCount}
+                  onCheckDuplicates={wb.checkDuplicates}
+                  onSave={wb.saveSelected}
+                  onSaved={() => wb.setToastState('账单已写入账本', 'success')}
+                />
               </div>
             </article>
           ) : null}
@@ -670,22 +646,6 @@ export function AssistantPage() {
       </section>
 
       <section className="chat-input-bar">
-        {mode === 'bookkeeping' ? (
-          <div className="chat-quick-amount-row">
-            <span>⚡ 快速建单</span>
-            {QUICK_AMOUNT_ACTIONS.map((amount) => (
-              <button
-                key={amount}
-                type="button"
-                onClick={() => wb.applyCommand(`刚刚支出${amount}元，用微信支付`)}
-                disabled={wb.status === 'recognizing'}
-              >
-                -¥{amount}
-              </button>
-            ))}
-          </div>
-        ) : null}
-
         <div className="chat-smart-command-row">
           {SMART_TRANSACTION_COMMANDS.map((item) => (
             <button

--- a/src/shared/lib/backup.ts
+++ b/src/shared/lib/backup.ts
@@ -121,7 +121,13 @@ function joinWebdavPath(endpoint: string, remoteFilePath: string): string {
 }
 
 function buildBasicAuth(username: string, password: string): string {
-  return `Basic ${window.btoa(`${username}:${password}`)}`;
+  const raw = `${username}:${password}`;
+  const bytes = new TextEncoder().encode(raw);
+  let binary = '';
+  bytes.forEach((value) => {
+    binary += String.fromCharCode(value);
+  });
+  return `Basic ${window.btoa(binary)}`;
 }
 
 export async function webdavUploadBackup(


### PR DESCRIPTION
### Motivation
- 修复用户报告的 WebDAV 上传失败问题，排查为 Basic Auth 在含非 ASCII 字符（例如中文）时编码不兼容导致。
- 隐藏后端返回的原始 JSON / 推理细节，前端仅展示可读的识别结果与是否保存的状态以减少用户困惑。
- 移除快捷建单入口以简化输入区交互，并将免责声明文本在输入区域居中显示。

### Description
- Assistant 页面：将展示逻辑从渲染原始推理/JSON 改为展示“识别结果”卡片，仅保留识别列表、检测重复与保存操作；移除“快速建单（-¥10/-¥20/-¥50/-¥100）”行；删除不再使用的 `previewPayload` 构造（`src/pages/assistant/AssistantPage.tsx`）。
- BillPreviewCard：移除 JSON 复制/折叠与原始 JSON 展示，调整工具栏 class 为 `.chat-preview-toolbar`，保存按钮在 `onSave()` 返回 true 时才触发 `onSaved()`（`src/features/assistant/ui/BillPreviewCard.tsx`）。
- Workbench 保存流程：`saveSelected` 增加返回值（`boolean`），在异常时设置 `error` 状态并展示错误 toast 与日志，避免前端在保存失败时误触发成功回调（`src/features/assistant/workbench/useAssistantWorkbench.ts`）。
- WebDAV 备份：`buildBasicAuth` 改为先通过 `TextEncoder` 做 UTF-8 编码再按字节构造二进制串后 `btoa`，以兼容中文用户名/密码等非 ASCII 场景（`src/shared/lib/backup.ts`）。
- 样式：重命名/替换预览工具栏样式，移除快捷建单 CSS，并将免责声明 `.chat-disclaimer` 文本居中（`src/app/styles/global.css`）。

### Testing
- 运行 `npm run build`（TypeScript 检查 + Vite 构建），构建成功（通过）。
- 运行 `npm run lint`（ESLint），静态检查与自动修复通过（通过）。
- 本地启动开发服务器并使用自动化脚本打开 `/assistant` 页面并截屏验证界面变更（Playwright 自动化执行并生成截图，执行成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f16552a68832799915d15780efe8b)