### PR TITLE
Fix WebDAV failures and improve AI assistant, account UI, backup/reset, and dashboard

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -1344,6 +1344,27 @@ small.mono {
   min-width: 0;
 }
 
+.stat-card-gradient {
+  position: relative;
+  overflow: hidden;
+}
+
+.stat-card-gradient::after {
+  content: '';
+  position: absolute;
+  width: 160px;
+  height: 160px;
+  right: -70px;
+  top: -80px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--color-primary) 22%, transparent),
+    transparent 70%
+  );
+  pointer-events: none;
+}
+
 .stat-card:hover {
   box-shadow: var(--shadow-sm);
 }
@@ -1756,6 +1777,10 @@ small.mono {
 .dashboard-top-list {
   display: grid;
   gap: var(--space-2);
+}
+
+.dashboard-core-top-list {
+  margin-top: var(--space-4);
 }
 
 .dashboard-top-item {
@@ -3008,12 +3033,13 @@ small.mono {
 
 .chat-input-form {
   display: flex;
-  align-items: flex-end;
+  align-items: stretch;
   gap: var(--space-2);
   padding: var(--space-3) var(--space-5);
   max-width: 780px;
   margin: 0 auto;
   width: 100%;
+  justify-content: space-between;
 }
 
 .chat-input-textarea {
@@ -3054,13 +3080,13 @@ small.mono {
 }
 
 .chat-upload-btn {
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 18px;
+  font-size: 22px;
   padding: 0;
   flex-shrink: 0;
   background: var(--color-bg-elevated);
@@ -3083,13 +3109,13 @@ small.mono {
 }
 
 .chat-send-btn {
-  width: 40px;
-  height: 40px;
+  width: 52px;
+  height: 48px;
   border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
+  font-size: 20px;
   padding: 0;
   flex-shrink: 0;
   border: 1px solid var(--color-primary-border);
@@ -3108,6 +3134,26 @@ small.mono {
   background: var(--color-bg-subtle);
   color: var(--color-text-placeholder);
   cursor: not-allowed;
+}
+
+.chat-latest-bill {
+  max-width: 780px;
+  width: 100%;
+  margin: 4px auto 0;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+}
+
+.chat-latest-bill strong {
+  color: var(--color-text);
+  font-size: var(--font-sm);
 }
 
 /* ============================================================
@@ -3199,15 +3245,22 @@ small.mono {
   }
 
   .chat-upload-btn {
-    width: 32px;
-    height: 32px;
-    font-size: 14px;
+    width: 40px;
+    height: 40px;
+    font-size: 18px;
   }
 
   .chat-send-btn {
-    width: 32px;
-    height: 32px;
-    font-size: 12px;
+    width: 44px;
+    height: 40px;
+    font-size: 18px;
+  }
+
+  .chat-latest-bill {
+    margin: 4px var(--space-3) 0;
+    width: auto;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .chat-msg-image {
@@ -4581,6 +4634,8 @@ small.mono {
   flex-direction: column;
   align-items: flex-end;
   gap: 4px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .account-card-balance-wrap small {
@@ -4589,7 +4644,7 @@ small.mono {
 }
 
 .account-card-balance {
-  font-size: clamp(18px, 2.2vw, 44px);
+  font-size: clamp(18px, 1.8vw, 34px);
   font-weight: 800;
   letter-spacing: 0.01em;
   line-height: 1;
@@ -5306,6 +5361,9 @@ small.mono {
   position: relative;
   margin-bottom: var(--space-3);
   padding-left: var(--space-2);
+  max-height: calc(100vh - 220px);
+  overflow-y: auto;
+  padding-right: var(--space-1);
 }
 
 .drawer-timeline::before {

--- a/src/features/transactions/components/TransactionDetailDrawer.tsx
+++ b/src/features/transactions/components/TransactionDetailDrawer.tsx
@@ -22,7 +22,7 @@ function statusLabel(status: TransactionStatus): string {
 function sourceLabel(source: TransactionSource): string {
   if (source === 'ai') return 'AI 记账';
   if (source === 'wechat') return '微信导入';
-  if (source === 'alipay') return '支付宝导入';
+  if (source === 'alipay') return '支付宝';
   return '手工录入';
 }
 
@@ -244,7 +244,7 @@ export function TransactionDetailDrawer({
               <strong>
                 {source === 'ai' ? <span className="badge badge-primary">AI 记账</span> : null}
                 {source === 'wechat' ? <span className="badge">微信导入</span> : null}
-                {source === 'alipay' ? <span className="badge">支付宝导入</span> : null}
+                {source === 'alipay' ? <span className="badge">支付宝</span> : null}
                 {source === 'manual' ? <span className="badge">手工录入</span> : null}
               </strong>
             </div>

--- a/src/features/transactions/components/TransactionFilters.tsx
+++ b/src/features/transactions/components/TransactionFilters.tsx
@@ -150,7 +150,7 @@ export function TransactionFilters({
                   <option value="all">全部来源</option>
                   <option value="manual">手工录入</option>
                   <option value="wechat">微信导入</option>
-                  <option value="alipay">支付宝导入</option>
+                  <option value="alipay">支付宝</option>
                   <option value="ai">AI 记账</option>
                 </select>
               </div>

--- a/src/pages/assistant/AssistantPage.tsx
+++ b/src/pages/assistant/AssistantPage.tsx
@@ -256,6 +256,13 @@ export function AssistantPage() {
   const [presetQuestions, setPresetQuestions] = useState<PresetQuestion[]>([]);
   const [loadingPresets, setLoadingPresets] = useState(false);
   const [chatHistory, setChatHistory] = useState<ChatHistoryItem[]>(() => readChatHistory(mode));
+  const latestTransaction = useMemo(
+    () =>
+      [...transactions]
+        .sort((a, b) => +new Date(b.date) - +new Date(a.date))
+        .find((item) => item.type !== 'budget') ?? null,
+    [transactions]
+  );
   const lastAssistantRef = useRef<Record<AssistantMode, string>>({
     bookkeeping: '',
     assistant: ''
@@ -693,7 +700,28 @@ export function AssistantPage() {
 
         <p className="chat-disclaimer">AI 生成内容仅供参考，请结合原始账单核对后再保存。</p>
 
+        {latestTransaction ? (
+          <div className="chat-latest-bill" aria-label="最近一笔账单">
+            <span>最近一笔</span>
+            <strong>
+              {latestTransaction.note || '未备注'} ·
+              {latestTransaction.type === 'income' ? ' +' : ' -'}¥
+              {latestTransaction.amount.toFixed(2)}
+            </strong>
+          </div>
+        ) : null}
+
         <form className="chat-input-form" onSubmit={onSubmit}>
+          <button
+            type="button"
+            className="chat-upload-btn"
+            title="上传图片"
+            onClick={() => wb.fileInputRef.current?.click()}
+            disabled={wb.status === 'recognizing'}
+          >
+            ＋
+          </button>
+
           <textarea
             ref={wb.textareaRef}
             className="chat-input-textarea"
@@ -714,16 +742,6 @@ export function AssistantPage() {
             aria-label="上传账单图片"
             onChange={(e) => void wb.handleSetImage(e.target.files?.[0])}
           />
-
-          <button
-            type="button"
-            className="chat-upload-btn"
-            title="上传图片"
-            onClick={() => wb.fileInputRef.current?.click()}
-            disabled={wb.status === 'recognizing'}
-          >
-            ＋
-          </button>
 
           <button
             type="submit"

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -641,26 +641,45 @@ export function DashboardPage() {
       <section className="panel">
         <h2>核心资产仪表盘</h2>
         <div className="grid grid-3">
-          <div className="stat-card stat-balance">
+          <div className="stat-card stat-balance stat-card-gradient">
             <span className="stat-icon">🧭</span>
             <div>
               <h3>净资产</h3>
               <strong className="stat-value">{formatCurrency(netAssets)}</strong>
             </div>
           </div>
-          <div className="stat-card stat-income">
+          <div className="stat-card stat-income stat-card-gradient">
             <span className="stat-icon">💎</span>
             <div>
               <h3>本月结余</h3>
               <strong className="stat-value">{formatCurrency(monthlyBalance)}</strong>
             </div>
           </div>
-          <div className="stat-card stat-expense">
+          <div className="stat-card stat-expense stat-card-gradient">
             <span className="stat-icon">📄</span>
             <div>
               <h3>欠款负债</h3>
               <strong className="stat-value">{formatCurrency(liabilities)}</strong>
             </div>
+          </div>
+        </div>
+        <div className="dashboard-core-top-list">
+          <div className="dashboard-section-header">
+            <h4>重点账目</h4>
+            <span>金额 TOP {displayTopTransactions.length}</span>
+          </div>
+          <div className="dashboard-top-list">
+            {displayTopTransactions.map((item, index) => (
+              <article key={`${item.date}-${index}`} className="dashboard-top-item">
+                <div>
+                  <p className="dashboard-top-title">
+                    {item.category || '未分类'} · {item.date}
+                  </p>
+                  <p className="dashboard-top-note">{item.note || '无备注'}</p>
+                </div>
+                <strong>{formatCurrency(item.amount)}</strong>
+              </article>
+            ))}
           </div>
         </div>
       </section>
@@ -798,26 +817,6 @@ export function DashboardPage() {
                       </article>
                     );
                   })}
-                </div>
-              </section>
-
-              <section>
-                <div className="dashboard-section-header">
-                  <h4>重点账目</h4>
-                  <span>金额 TOP {displayTopTransactions.length}</span>
-                </div>
-                <div className="dashboard-top-list">
-                  {displayTopTransactions.map((item, index) => (
-                    <article key={`${item.date}-${index}`} className="dashboard-top-item">
-                      <div>
-                        <p className="dashboard-top-title">
-                          {item.category || '未分类'} · {item.date}
-                        </p>
-                        <p className="dashboard-top-note">{item.note || '无备注'}</p>
-                      </div>
-                      <strong>{formatCurrency(item.amount)}</strong>
-                    </article>
-                  ))}
                 </div>
               </section>
             </div>

--- a/src/pages/database-settings/DatabaseSettingsPage.tsx
+++ b/src/pages/database-settings/DatabaseSettingsPage.tsx
@@ -11,6 +11,7 @@ import {
   webdavUploadBackup
 } from '../../shared/lib/backup';
 import { useFinanceStore } from '../../shared/store/useFinanceStore';
+import { ConfirmDialog } from '../../shared/ui/ConfirmDialog';
 import { Toast, ToastVariant } from '../../shared/ui/Toast';
 
 type BillSource = 'wechat' | 'alipay';
@@ -23,6 +24,7 @@ export function DatabaseSettingsPage() {
   const addCategory = useFinanceStore((s) => s.addCategory);
   const addAccount = useFinanceStore((s) => s.addAccount);
   const replaceAllData = useFinanceStore((s) => s.replaceAllData);
+  const clearAllAccountBills = useFinanceStore((s) => s.clearAllAccountBills);
 
   const backupInputRef = useRef<HTMLInputElement | null>(null);
   const billInputRef = useRef<HTMLInputElement | null>(null);
@@ -36,6 +38,7 @@ export function DatabaseSettingsPage() {
   });
 
   const [webdav, setWebdav] = useState<BackupWebdavConfig>(() => loadWebdavConfig());
+  const [clearBillsOpen, setClearBillsOpen] = useState(false);
 
   const totalRows = useMemo(
     () => transactions.length + categories.length + accounts.length,
@@ -232,6 +235,14 @@ export function DatabaseSettingsPage() {
       </section>
 
       <section className="panel" style={{ marginTop: 12 }}>
+        <h3 style={{ marginTop: 0 }}>数据重制</h3>
+        <p className="sync-tip">清空所有账户账单（交易记录），保留账户与分类。</p>
+        <button type="button" className="danger" onClick={() => setClearBillsOpen(true)}>
+          一键清空所有账户账单
+        </button>
+      </section>
+
+      <section className="panel" style={{ marginTop: 12 }}>
         <h3 style={{ marginTop: 0 }}>WebDAV 同步</h3>
         <div className="grid grid-2" style={{ gap: 10 }}>
           <div className="field" style={{ marginBottom: 0 }}>
@@ -296,6 +307,21 @@ export function DatabaseSettingsPage() {
         variant={toast.variant}
         message={toast.message}
         onClose={() => setToast((prev) => ({ ...prev, visible: false }))}
+      />
+
+      <ConfirmDialog
+        open={clearBillsOpen}
+        title="确认清空账单"
+        description={`将清空全部 ${transactions.length} 条交易，账户余额会按初始值重算。此操作不可恢复。`}
+        confirmText="确认清空"
+        cancelText="取消"
+        danger
+        onCancel={() => setClearBillsOpen(false)}
+        onConfirm={() => {
+          clearAllAccountBills();
+          setClearBillsOpen(false);
+          showToast('已清空所有账户账单', 'success');
+        }}
       />
     </div>
   );

--- a/src/shared/lib/backup.ts
+++ b/src/shared/lib/backup.ts
@@ -120,6 +120,40 @@ function joinWebdavPath(endpoint: string, remoteFilePath: string): string {
   return `${base}/${path}`;
 }
 
+function normalizeWebdavError(action: '上传' | '下载' | '创建目录', error: unknown): Error {
+  if (error instanceof Error) {
+    if (error.message.includes('Failed to fetch')) {
+      return new Error(`WebDAV ${action}失败：网络连接或跨域(CORS)被拦截，请检查地址与服务端配置`);
+    }
+    return error;
+  }
+  return new Error(`WebDAV ${action}失败，请稍后重试`);
+}
+
+async function ensureWebdavDirectories(config: BackupWebdavConfig): Promise<void> {
+  const normalizedPath = config.remoteFilePath.replace(/^\/+/, '').split('/').filter(Boolean);
+  if (normalizedPath.length <= 1) {
+    return;
+  }
+
+  const folders = normalizedPath.slice(0, -1);
+  const base = config.endpoint.replace(/\/+$/, '');
+  let current = '';
+  for (const segment of folders) {
+    current = current ? `${current}/${segment}` : segment;
+    const response = await fetch(`${base}/${current}`, {
+      method: 'MKCOL',
+      headers: {
+        Authorization: buildBasicAuth(config.username, config.password)
+      }
+    });
+
+    if (![200, 201, 204, 301, 302, 405].includes(response.status)) {
+      throw new Error(`WebDAV 目录创建失败（${current}，HTTP ${response.status}）`);
+    }
+  }
+}
+
 function buildBasicAuth(username: string, password: string): string {
   const raw = `${username}:${password}`;
   const bytes = new TextEncoder().encode(raw);
@@ -134,36 +168,45 @@ export async function webdavUploadBackup(
   config: BackupWebdavConfig,
   payload: FinanceBackupPayload
 ): Promise<void> {
-  const url = joinWebdavPath(config.endpoint, config.remoteFilePath);
-  const response = await fetch(url, {
-    method: 'PUT',
-    headers: {
-      Authorization: buildBasicAuth(config.username, config.password),
-      'Content-Type': 'application/json;charset=utf-8'
-    },
-    body: JSON.stringify(payload, null, 2)
-  });
+  try {
+    await ensureWebdavDirectories(config);
+    const url = joinWebdavPath(config.endpoint, config.remoteFilePath);
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        Authorization: buildBasicAuth(config.username, config.password),
+        'Content-Type': 'application/json;charset=utf-8'
+      },
+      body: JSON.stringify(payload, null, 2)
+    });
 
-  if (!response.ok) {
-    throw new Error(`WebDAV 上传失败（HTTP ${response.status}）`);
+    if (!response.ok) {
+      throw new Error(`WebDAV 上传失败（HTTP ${response.status}）`);
+    }
+  } catch (error) {
+    throw normalizeWebdavError('上传', error);
   }
 }
 
 export async function webdavDownloadBackup(
   config: BackupWebdavConfig
 ): Promise<FinanceBackupPayload> {
-  const url = joinWebdavPath(config.endpoint, config.remoteFilePath);
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: {
-      Authorization: buildBasicAuth(config.username, config.password)
+  try {
+    const url = joinWebdavPath(config.endpoint, config.remoteFilePath);
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: buildBasicAuth(config.username, config.password)
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`WebDAV 下载失败（HTTP ${response.status}）`);
     }
-  });
 
-  if (!response.ok) {
-    throw new Error(`WebDAV 下载失败（HTTP ${response.status}）`);
+    const text = await response.text();
+    return parseFinanceBackupPayload(text);
+  } catch (error) {
+    throw normalizeWebdavError('下载', error);
   }
-
-  const text = await response.text();
-  return parseFinanceBackupPayload(text);
 }

--- a/src/shared/lib/billImport.ts
+++ b/src/shared/lib/billImport.ts
@@ -297,7 +297,7 @@ export function parseBillCsvToTransactions(input: ParseBillInput): Omit<Transact
       amount,
       date: parseDate(dateRaw),
       note: buildNote(row),
-      tags: [input.source === 'wechat' ? '微信导入' : '支付宝导入'],
+      tags: [input.source === 'wechat' ? '微信导入' : '支付宝'],
       categoryId: input.defaultCategoryId,
       accountId: input.defaultAccountId,
       source: input.source,

--- a/src/shared/store/useFinanceStore.ts
+++ b/src/shared/store/useFinanceStore.ts
@@ -18,6 +18,7 @@ interface FinanceState {
   addAccount: (name: string, type?: Account['type'], initialBalance?: number) => string;
   updateAccountBalance: (id: string, balance: number) => void;
   removeAccount: (id: string) => void;
+  clearAllAccountBills: () => void;
   replaceAllData: (payload: {
     transactions: TransactionItem[];
     categories: Category[];
@@ -253,6 +254,12 @@ export const useFinanceStore = create<FinanceState>()(
       removeAccount: (id) => {
         set((s) => ({ accounts: s.accounts.filter((item) => item.id !== id) }));
         void syncChangeIfNeeded({ entity: 'accounts', action: 'delete', id });
+      },
+      clearAllAccountBills: () => {
+        set((s) => ({
+          transactions: [],
+          accounts: computeAccountBalances(s.accounts, [])
+        }));
       },
       replaceAllData: (payload) => {
         const incomingCategories = Array.isArray(payload.categories) ? payload.categories : [];

--- a/src/widgets/layout/AppLayout.tsx
+++ b/src/widgets/layout/AppLayout.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react';
 import { Link, NavLink, Outlet } from 'react-router-dom';
 import { ThemeSwitcher } from '../../features/theme-switcher/ThemeSwitcher';
 import { formatCurrency } from '../../shared/lib/format';
-import { useAiSettings } from '../../shared/store/useAiSettings';
 import { useFinanceStore } from '../../shared/store/useFinanceStore';
 
 /** 当前发布版本号（展示用途，与 package.json 可独立管理） */
@@ -83,8 +82,6 @@ const mobileQuickGroups: Array<{ title: string; items: QuickEntry[] }> = [
 const SIDEBAR_COLLAPSED_WIDTH = 76;
 const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 420;
-const FLOAT_HELP_POS_KEY = 'ledgerflow.floatingHelp.position';
-
 const monthLabel = new Intl.DateTimeFormat('zh-CN', {
   year: 'numeric',
   month: 'long'
@@ -99,19 +96,10 @@ export function AppLayout() {
   const [collapsed, setCollapsed] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(260);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [envOpen, setEnvOpen] = useState(false);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
-  const [helpButtonPos, setHelpButtonPos] = useState({ x: 0, y: 0 });
 
   const draggingRef = useRef(false);
-  const floatingDragOffsetRef = useRef({ x: 0, y: 0 });
-  const floatingDraggingRef = useRef(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
-  const envRef = useRef<HTMLDivElement | null>(null);
-
-  const baseUrl = useAiSettings((s) => s.baseUrl);
-  const model = useAiSettings((s) => s.model);
-  const apiKey = useAiSettings((s) => s.apiKey);
   const transactions = useFinanceStore((s) => s.transactions);
 
   const thisMonth = new Date();
@@ -153,60 +141,10 @@ export function AppLayout() {
   }, [collapsed]);
 
   useEffect(() => {
-    try {
-      const raw = window.localStorage.getItem(FLOAT_HELP_POS_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw) as { x?: number; y?: number };
-        if (typeof parsed.x === 'number' && typeof parsed.y === 'number') {
-          setHelpButtonPos({ x: parsed.x, y: parsed.y });
-          return;
-        }
-      }
-    } catch {
-      // ignore parse errors
-    }
-    setHelpButtonPos({
-      x: Math.max(16, window.innerWidth - 140),
-      y: Math.max(16, window.innerHeight - 84)
-    });
-  }, []);
-
-  useEffect(() => {
-    const onPointerMove = (event: PointerEvent) => {
-      if (!floatingDraggingRef.current) return;
-      const nextX = event.clientX - floatingDragOffsetRef.current.x;
-      const nextY = event.clientY - floatingDragOffsetRef.current.y;
-      const clampedX = Math.max(8, Math.min(nextX, window.innerWidth - 124));
-      const clampedY = Math.max(8, Math.min(nextY, window.innerHeight - 52));
-      setHelpButtonPos({ x: clampedX, y: clampedY });
-    };
-
-    const onPointerUp = () => {
-      if (!floatingDraggingRef.current) return;
-      floatingDraggingRef.current = false;
-      try {
-        window.localStorage.setItem(FLOAT_HELP_POS_KEY, JSON.stringify(helpButtonPos));
-      } catch {
-        // ignore storage errors
-      }
-    };
-
-    window.addEventListener('pointermove', onPointerMove);
-    window.addEventListener('pointerup', onPointerUp);
-    return () => {
-      window.removeEventListener('pointermove', onPointerMove);
-      window.removeEventListener('pointerup', onPointerUp);
-    };
-  }, [helpButtonPos]);
-
-  useEffect(() => {
     const onClickOutside = (event: MouseEvent) => {
       const target = event.target as Node;
       if (menuRef.current && !menuRef.current.contains(target)) {
         setMenuOpen(false);
-      }
-      if (envRef.current && !envRef.current.contains(target)) {
-        setEnvOpen(false);
       }
     };
 
@@ -224,15 +162,6 @@ export function AppLayout() {
       document.body.style.overflow = '';
     };
   }, [mobileNavOpen]);
-
-  const copyBaseUrl = async () => {
-    try {
-      await navigator.clipboard.writeText(baseUrl || '');
-      setEnvOpen(false);
-    } catch {
-      setEnvOpen(false);
-    }
-  };
 
   return (
     <div
@@ -424,50 +353,6 @@ export function AppLayout() {
           </aside>
         </div>
       ) : null}
-
-      <div
-        className="floating-help-wrap"
-        ref={envRef}
-        style={{ left: `${helpButtonPos.x}px`, top: `${helpButtonPos.y}px` }}
-      >
-        <button
-          type="button"
-          className="floating-help-btn"
-          aria-haspopup="dialog"
-          aria-expanded={envOpen}
-          onClick={() => setEnvOpen((v) => !v)}
-          onPointerDown={(event) => {
-            floatingDraggingRef.current = true;
-            floatingDragOffsetRef.current = {
-              x: event.clientX - helpButtonPos.x,
-              y: event.clientY - helpButtonPos.y
-            };
-          }}
-        >
-          {apiKey ? 'AI 已配置' : 'AI 未配置'}
-        </button>
-        {envOpen ? (
-          <div className="env-popover floating-help-popover" role="dialog" aria-label="环境信息">
-            <h4>环境信息</h4>
-            <p>
-              <strong>模型：</strong>
-              {model || '未设置'}
-            </p>
-            <p>
-              <strong>Base URL：</strong>
-              <span className="mono-inline">{baseUrl || '未设置'}</span>
-            </p>
-            <div className="row" style={{ marginTop: 8 }}>
-              <button type="button" onClick={() => void copyBaseUrl()}>
-                复制 Base URL
-              </button>
-              <Link to="/settings" onClick={() => setEnvOpen(false)}>
-                <button type="button">前往设置</button>
-              </Link>
-            </div>
-          </div>
-        ) : null}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Fix opaque WebDAV upload/download failures by surfacing clearer errors and making uploads robust when remote directories don't exist.
- Improve AI assistant input UX and contextual help so users can upload images more easily and see the most recent bill at a glance.
- Prevent account balance visual overflow and add a safe way for users to reset transaction data when needed.
- Make transaction detail timeline scrollable and consolidate the “重点账目” list into the core assets dashboard with subtle visual polish.

### Description
- WebDAV: add error normalization and clearer messages and implement `MKCOL`-based directory creation before `PUT` to avoid silent upload failures (`src/shared/lib/backup.ts`).
- Data reset: add `clearAllAccountBills` to the finance store and wire a “一键清空所有账户账单” button with confirm dialog in settings to clear transactions and recompute balances (`src/shared/store/useFinanceStore.ts`, `src/pages/database-settings/DatabaseSettingsPage.tsx`).
- AI assistant: move the attachment/upload `＋` button to the left, enlarge the send button, align the chat input horizontally, and show the most recent transaction summary above the input (`src/pages/assistant/AssistantPage.tsx`, `src/app/styles/global.css`).
- Labels and import tags: change "支付宝导入" phrasing to "支付宝" across transaction detail, filters, and import tags so source labels are consistent (`src/features/transactions/components/TransactionDetailDrawer.tsx`, `src/features/transactions/components/TransactionFilters.tsx`, `src/shared/lib/billImport.ts`).
- Transaction detail: keep professional/timeline mode and make the timeline container scrollable for long histories (`src/app/styles/global.css`, `src/features/transactions/components/TransactionDetailDrawer.tsx`).
- Dashboard: merge the previous “重点账目” into the core assets section and add a subtle gradient decorative accent on stat cards (`src/pages/dashboard/DashboardPage.tsx`, `src/app/styles/global.css`).
- Layout & visuals: remove the floating "AI 已配置" help button and its popover to reduce UI noise, and tighten account balance typography/constraints to avoid overflow (`src/widgets/layout/AppLayout.tsx`, `src/app/styles/global.css`).
- Minor: CSS adjustments for responsive chat controls and account card balance sizing and overflow handling (`src/app/styles/global.css`).

### Testing
- Built production bundle with `npm run build` and the build completed successfully.
- Started dev server (`npm run dev`) and validated pages; automated Playwright screenshots were produced using Firefox for the assistant, dashboard, and settings pages.
- Attempted Chromium-based Playwright screenshot which failed in the environment due to a Chromium crash (SIGSEGV) but the Firefox run succeeded and artifacts were generated.
- Ran a quick text search to confirm the old "支付宝导入" string no longer exists (`rg -n "支付宝导入" src`) which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fee8445648329b4303d40b72fe271)