### PR TITLE
修复 WebDAV 跨域上传失败并新增账单导入模式（增量/合并/覆盖）

### DIFF
--- a/src/features/transactions/components/TransactionFilters.tsx
+++ b/src/features/transactions/components/TransactionFilters.tsx
@@ -7,6 +7,7 @@ import {
   TransactionTypeFilter
 } from '../hooks/useTransactionFilters';
 import { TransactionColumnKey } from './TransactionTable';
+import { BillImportMode } from '../../../shared/lib/billImport';
 
 interface TransactionFiltersProps {
   filters: TransactionFilterState;
@@ -20,6 +21,8 @@ interface TransactionFiltersProps {
   onExport: () => void;
   onImportWechat: () => void;
   onImportAlipay: () => void;
+  importMode: BillImportMode;
+  onImportModeChange: (mode: BillImportMode) => void;
   onCheckDuplicates: () => void;
   columnOptions: Array<{ key: TransactionColumnKey; label: string }>;
   visibleColumns: Record<TransactionColumnKey, boolean>;
@@ -38,6 +41,8 @@ export function TransactionFilters({
   onExport,
   onImportWechat,
   onImportAlipay,
+  importMode,
+  onImportModeChange,
   onCheckDuplicates,
   columnOptions,
   visibleColumns,
@@ -179,6 +184,19 @@ export function TransactionFilters({
 
               <div className="transaction-context-divider" />
               <p className="transaction-filter-section-title">更多操作</p>
+              <div className="field" style={{ marginBottom: 8 }}>
+                <label htmlFor="tx-import-mode">账单导入模式</label>
+                <select
+                  id="tx-import-mode"
+                  aria-label="账单导入模式"
+                  value={importMode}
+                  onChange={(event) => onImportModeChange(event.target.value as BillImportMode)}
+                >
+                  <option value="incremental">增量（跳过重复）</option>
+                  <option value="merge">合并（覆盖重复）</option>
+                  <option value="overwrite">覆盖（清空后导入）</option>
+                </select>
+              </div>
               <div className="transaction-filter-actions-grid">
                 <button type="button" onClick={onExport}>
                   导出 CSV

--- a/src/pages/database-settings/DatabaseSettingsPage.tsx
+++ b/src/pages/database-settings/DatabaseSettingsPage.tsx
@@ -1,5 +1,9 @@
 import { ChangeEvent, useMemo, useRef, useState } from 'react';
-import { parseBillCsvToTransactions } from '../../shared/lib/billImport';
+import {
+  applyBillImportMode,
+  BillImportMode,
+  parseBillCsvToTransactions
+} from '../../shared/lib/billImport';
 import {
   BackupWebdavConfig,
   createFinanceBackupPayload,
@@ -21,6 +25,7 @@ export function DatabaseSettingsPage() {
   const categories = useFinanceStore((s) => s.categories);
   const accounts = useFinanceStore((s) => s.accounts);
   const addTransaction = useFinanceStore((s) => s.addTransaction);
+  const updateTransaction = useFinanceStore((s) => s.updateTransaction);
   const addCategory = useFinanceStore((s) => s.addCategory);
   const addAccount = useFinanceStore((s) => s.addAccount);
   const replaceAllData = useFinanceStore((s) => s.replaceAllData);
@@ -30,6 +35,7 @@ export function DatabaseSettingsPage() {
   const billInputRef = useRef<HTMLInputElement | null>(null);
 
   const [importSource, setImportSource] = useState<BillSource | null>(null);
+  const [importMode, setImportMode] = useState<BillImportMode>('incremental');
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<{ visible: boolean; variant: ToastVariant; message: string }>({
     visible: false,
@@ -106,9 +112,27 @@ export function DatabaseSettingsPage() {
         return;
       }
 
-      rows.forEach((row) => addTransaction(row));
+      const result = applyBillImportMode({
+        mode: importMode,
+        existing: transactions,
+        incoming: rows
+      });
+
+      if (result.shouldClearBeforeImport) {
+        clearAllAccountBills();
+      }
+
+      result.update.forEach((row) => updateTransaction(row.id, row.payload));
+      result.append.forEach((row) => addTransaction(row));
+
+      const changedCount = result.append.length + result.update.length;
+      if (changedCount === 0) {
+        showToast('导入完成：增量模式下未发现可新增或更新的账单', 'warning');
+        return;
+      }
+
       showToast(
-        `${source === 'wechat' ? '微信' : '支付宝'}账单导入成功：${rows.length} 条`,
+        `${source === 'wechat' ? '微信' : '支付宝'}账单导入成功：新增 ${result.append.length} 条，更新 ${result.update.length} 条${result.skipped ? `，跳过 ${result.skipped} 条` : ''}`,
         'success'
       );
     } catch {
@@ -204,6 +228,18 @@ export function DatabaseSettingsPage() {
         <h3 style={{ marginTop: 0 }}>账单 CSV 导入</h3>
         <p className="sync-tip">支持微信、支付宝官方账单 CSV / TXT（含制表符）格式。</p>
         <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            导入模式
+            <select
+              aria-label="账单导入模式"
+              value={importMode}
+              onChange={(e) => setImportMode(e.target.value as BillImportMode)}
+            >
+              <option value="incremental">增量（跳过重复）</option>
+              <option value="merge">合并（覆盖重复）</option>
+              <option value="overwrite">覆盖（清空后导入）</option>
+            </select>
+          </label>
           <button
             type="button"
             onClick={() => {

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -2,7 +2,11 @@ import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useFinanceStore } from '../../shared/store/useFinanceStore';
 import { exportTransactionsCsv } from '../../shared/lib/csv';
-import { parseBillCsvToTransactions } from '../../shared/lib/billImport';
+import {
+  applyBillImportMode,
+  BillImportMode,
+  parseBillCsvToTransactions
+} from '../../shared/lib/billImport';
 import { formatDate } from '../../shared/lib/format';
 import { Toast, ToastVariant } from '../../shared/ui/Toast';
 import { ConfirmDialog } from '../../shared/ui/ConfirmDialog';
@@ -199,12 +203,12 @@ function decodeBillFileText(file: File): Promise<string> {
 function detectSource(
   source: TransactionSource | undefined,
   note: string,
-  tags: string[]
+  tags: string[] | undefined
 ): TransactionSource {
   if (source) {
     return source;
   }
-  const combined = `${note} ${tags.join(' ')}`;
+  const combined = `${note} ${(tags || []).join(' ')}`;
   if (/微信|wechat/i.test(combined)) {
     return 'wechat';
   }
@@ -275,6 +279,7 @@ export function TransactionsPage() {
   const addTransaction = useFinanceStore((s) => s.addTransaction);
   const updateTransaction = useFinanceStore((s) => s.updateTransaction);
   const removeTransaction = useFinanceStore((s) => s.removeTransaction);
+  const clearAllAccountBills = useFinanceStore((s) => s.clearAllAccountBills);
 
   const {
     filters,
@@ -293,6 +298,7 @@ export function TransactionsPage() {
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
   const [importSource, setImportSource] = useState<BillSource | null>(null);
+  const [importMode, setImportMode] = useState<BillImportMode>('incremental');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [pendingDeleteIds, setPendingDeleteIds] = useState<string[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -420,7 +426,7 @@ export function TransactionsPage() {
       const byKeyword =
         filters.keyword.trim().length === 0 ||
         item.note.toLowerCase().includes(filters.keyword.toLowerCase()) ||
-        item.tags.join(',').toLowerCase().includes(filters.keyword.toLowerCase());
+        (item.tags || []).join(',').toLowerCase().includes(filters.keyword.toLowerCase());
 
       let byDate = true;
       if (dateRange.from && dateRange.to) {
@@ -465,7 +471,8 @@ export function TransactionsPage() {
       const merchantOrderNoPass =
         !merchantOrderNoFilter ||
         (row.item.merchantOrderNo || '').toLowerCase().includes(merchantOrderNoFilter);
-      const tagsPass = !tagsFilter || row.item.tags.join(',').toLowerCase().includes(tagsFilter);
+      const tagsPass =
+        !tagsFilter || (row.item.tags || []).join(',').toLowerCase().includes(tagsFilter);
       const merchantPass =
         !merchantFilter ||
         (row.item.note || '').toLowerCase().includes(merchantFilter) ||
@@ -610,18 +617,42 @@ export function TransactionsPage() {
         categoryId: resolveImportedCategoryId(item, categories, defaultCategoryId)
       }));
 
-      const insertedIds = normalizedParsed.map((item) => addTransaction(item));
+      const result = applyBillImportMode({
+        mode: importMode,
+        existing: transactions,
+        incoming: normalizedParsed
+      });
+
+      if (result.shouldClearBeforeImport) {
+        clearAllAccountBills();
+      }
+
+      result.update.forEach((row) => updateTransaction(row.id, row.payload));
+      const insertedIds = result.append.map((item) => addTransaction(item));
       const newestId = insertedIds[insertedIds.length - 1];
-      const expectedIndex = Math.max(0, filteredRows.length + normalizedParsed.length - 1);
+      const changedCount = result.append.length + result.update.length;
+      const expectedIndex = Math.max(0, filteredRows.length + result.append.length - 1);
       const expectedPage = Math.floor(expectedIndex / pageSize) + 1;
       setPage(expectedPage);
-      const message = `导入成功：新增 ${normalizedParsed.length} 条记录。`;
+
+      if (changedCount === 0) {
+        const message = `导入完成：${result.skipped} 条重复记录已跳过（增量模式）。`;
+        showToast(message, 'warning');
+        showImportNotice(message, 'warning');
+        return;
+      }
+
+      const actionLabel =
+        importMode === 'overwrite' ? '覆盖' : importMode === 'merge' ? '合并' : '增量导入';
+      const message = `导入成功（${actionLabel}）：新增 ${result.append.length} 条，更新 ${result.update.length} 条${result.skipped ? `，跳过 ${result.skipped} 条` : ''}。`;
       showToast(message, 'success');
       showImportNotice(`${message} 已自动定位到最新一条。`, 'success');
 
-      const next = new URLSearchParams(searchParams);
-      next.set('highlight', newestId);
-      setSearchParams(next, { replace: true });
+      if (newestId) {
+        const next = new URLSearchParams(searchParams);
+        next.set('highlight', newestId);
+        setSearchParams(next, { replace: true });
+      }
     } catch {
       const message = '导入失败：文件解析异常。';
       showToast(message, 'error');
@@ -852,6 +883,8 @@ export function TransactionsPage() {
         onExport={() => exportTransactionsCsv(filteredRows)}
         onImportWechat={() => openImport('wechat')}
         onImportAlipay={() => openImport('alipay')}
+        importMode={importMode}
+        onImportModeChange={setImportMode}
         onCheckDuplicates={handleCheckDuplicates}
         columnOptions={COLUMN_OPTIONS}
         visibleColumns={visibleColumns}

--- a/src/shared/lib/backup.ts
+++ b/src/shared/lib/backup.ts
@@ -141,12 +141,18 @@ async function ensureWebdavDirectories(config: BackupWebdavConfig): Promise<void
   let current = '';
   for (const segment of folders) {
     current = current ? `${current}/${segment}` : segment;
-    const response = await fetch(`${base}/${current}`, {
-      method: 'MKCOL',
-      headers: {
-        Authorization: buildBasicAuth(config.username, config.password)
-      }
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${base}/${current}`, {
+        method: 'MKCOL',
+        headers: {
+          Authorization: buildBasicAuth(config.username, config.password)
+        }
+      });
+    } catch {
+      // 某些 WebDAV 服务不允许跨域 MKCOL（但允许 PUT），目录创建失败时交给后续 PUT 决定。
+      continue;
+    }
 
     if (![200, 201, 204, 301, 302, 405].includes(response.status)) {
       throw new Error(`WebDAV 目录创建失败（${current}，HTTP ${response.status}）`);

--- a/src/shared/lib/billImport.ts
+++ b/src/shared/lib/billImport.ts
@@ -9,6 +9,21 @@ interface ParseBillInput {
   defaultAccountId: string;
 }
 
+export type BillImportMode = 'incremental' | 'merge' | 'overwrite';
+
+interface ApplyBillImportModeInput {
+  mode: BillImportMode;
+  existing: TransactionItem[];
+  incoming: Omit<TransactionItem, 'id'>[];
+}
+
+interface ApplyBillImportModeResult {
+  append: Omit<TransactionItem, 'id'>[];
+  update: Array<{ id: string; payload: Omit<TransactionItem, 'id'> }>;
+  skipped: number;
+  shouldClearBeforeImport: boolean;
+}
+
 const DATE_KEYS = [
   '交易时间',
   '入账时间',
@@ -102,6 +117,71 @@ function parseAmount(raw: string): number {
   if (!Number.isFinite(value)) return 0;
   // 统一两位小数，避免浮点误差导致金额展示异常。
   return Math.round(Math.abs(value) * 100) / 100;
+}
+
+function buildBillIdentity(item: {
+  date: string;
+  amount: number;
+  type: string;
+  note: string;
+  orderNo?: string;
+  merchantOrderNo?: string;
+}): string {
+  const orderNo = String(item.orderNo || '').trim();
+  if (orderNo) {
+    return `order:${orderNo}`;
+  }
+
+  const merchantOrderNo = String(item.merchantOrderNo || '').trim();
+  if (merchantOrderNo) {
+    return `merchant:${merchantOrderNo}`;
+  }
+
+  const amount = Math.round(Math.abs(Number(item.amount || 0)) * 100) / 100;
+  return `content:${String(item.date || '').slice(0, 10)}|${amount}|${String(item.type || '')}|${String(item.note || '').trim()}`;
+}
+
+export function applyBillImportMode(input: ApplyBillImportModeInput): ApplyBillImportModeResult {
+  const existingByIdentity = new Map<string, TransactionItem>();
+  input.existing.forEach((item) => {
+    existingByIdentity.set(buildBillIdentity(item), item);
+  });
+
+  if (input.mode === 'overwrite') {
+    return {
+      append: input.incoming,
+      update: [],
+      skipped: 0,
+      shouldClearBeforeImport: true
+    };
+  }
+
+  const append: Omit<TransactionItem, 'id'>[] = [];
+  const update: Array<{ id: string; payload: Omit<TransactionItem, 'id'> }> = [];
+  let skipped = 0;
+
+  input.incoming.forEach((item) => {
+    const identity = buildBillIdentity(item);
+    const existing = existingByIdentity.get(identity);
+    if (!existing) {
+      append.push(item);
+      return;
+    }
+
+    if (input.mode === 'merge') {
+      update.push({ id: existing.id, payload: item });
+      return;
+    }
+
+    skipped += 1;
+  });
+
+  return {
+    append,
+    update,
+    skipped,
+    shouldClearBeforeImport: false
+  };
 }
 
 function parseType(row: Record<string, string>, amountRaw: string): 'income' | 'expense' {


### PR DESCRIPTION
### Motivation
- 修复在某些 WebDAV 服务下，浏览器因跨域（CORS）拦截 `MKCOL` 导致备份上传失败的问题，从而无法执行远程备份/恢复。 
- 解决交易记录页面因 `tags` 可能为 `undefined` 而触发的筛选/来源判定异常，导致看不到交易记录的运行时问题。 
- 为支付宝/微信账单导入提供更灵活的策略（增量/合并/覆盖），以便用户可选择跳过、合并或完全覆盖历史账单。 

### Description
- 在 `src/shared/lib/backup.ts` 中修改 `ensureWebdavDirectories`：对 `MKCOL` 请求增加 `try/catch`，当浏览器因跨域拦截失败时继续后续流程，交由后续 `PUT` 决定是否成功。 
- 在 `src/shared/lib/billImport.ts` 中新增 `BillImportMode` 类型与 `applyBillImportMode` 函数，用订单号/商家订单号/内容签名判重并返回 `append/update/skipped/shouldClearBeforeImport`。 
- 在 `src/pages/transactions/TransactionsPage.tsx` 中：对 `tags` 访问添加兜底 `(item.tags || [])`，引入并维护 `importMode` 状态，导入时调用 `applyBillImportMode` 执行增量/合并/覆盖逻辑并展示新增/更新/跳过统计。 
- 在 `src/features/transactions/components/TransactionFilters.tsx` 与 `src/pages/database-settings/DatabaseSettingsPage.tsx` 中增加“账单导入模式”下拉控件，并将选择传递到导入逻辑以统一行为。 

### Testing
- 执行 `npm run build`（包含 `tsc --noEmit` + `vite build`）通过并生成生产包。 
- 启动开发服务器并使用自动化脚本（Playwright）访问 `/#/transactions`、打开“筛选与操作”面板并截图验证新增的“账单导入模式”控件可见，脚本运行成功并生成截图。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900fa171ec8331973119ca54d9f0d7)