### PR TITLE
fix: 修复交易筛选空列表，改进 WebDAV 提示并优化汇率计算器布局

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -4151,6 +4151,10 @@ small.mono {
   grid-column: span 1;
 }
 
+.exchange-key-zero {
+  grid-column: span 2;
+}
+
 .exchange-calculator-error {
   margin: 0;
   color: var(--color-danger);

--- a/src/features/exchange/ui/ExchangeConverter.tsx
+++ b/src/features/exchange/ui/ExchangeConverter.tsx
@@ -192,12 +192,13 @@ export function ExchangeConverter({ rates, base }: ExchangeConverterProps) {
             const isNum = /^\d$/.test(key) || key === '.';
             const isOperator = ['÷', '×', '-', '+', '='].includes(key);
             const isDanger = key === 'C' || key === '⌫';
+            const isZero = key === '0';
 
             return (
               <button
                 key={key}
                 type="button"
-                className={`exchange-key ${isNum ? 'exchange-key-num' : ''} ${isOperator ? 'exchange-key-op' : ''} ${isDanger ? 'exchange-key-danger' : ''} ${key === '=' ? 'exchange-key-equal primary' : ''}`.trim()}
+                className={`exchange-key ${isNum ? 'exchange-key-num' : ''} ${isOperator ? 'exchange-key-op' : ''} ${isDanger ? 'exchange-key-danger' : ''} ${isZero ? 'exchange-key-zero' : ''} ${key === '=' ? 'exchange-key-equal primary' : ''}`.trim()}
                 onClick={() => applyKey(key)}
               >
                 {key}

--- a/src/pages/database-settings/DatabaseSettingsPage.tsx
+++ b/src/pages/database-settings/DatabaseSettingsPage.tsx
@@ -280,6 +280,10 @@ export function DatabaseSettingsPage() {
 
       <section className="panel" style={{ marginTop: 12 }}>
         <h3 style={{ marginTop: 0 }}>WebDAV 同步</h3>
+        <p className="sync-tip" style={{ marginTop: 0 }}>
+          若浏览器提示跨域(CORS)或 Failed to fetch，优先改用同源代理地址（如
+          /api/webdav），再由服务端反向代理到真实 WebDAV。
+        </p>
         <div className="grid grid-2" style={{ gap: 10 }}>
           <div className="field" style={{ marginBottom: 0 }}>
             <label>WebDAV 地址</label>

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -450,10 +450,17 @@ export function TransactionsPage() {
     const dateFilter = quickFilters.date.trim().toLowerCase();
     const categoryFilter = quickFilters.category.trim().toLowerCase();
     const accountFilter = quickFilters.account.trim().toLowerCase();
-    const amountMin = Number(quickFilters.amountMin || '');
-    const amountMax = Number(quickFilters.amountMax || '');
-    const hasAmountMin = Number.isFinite(amountMin);
-    const hasAmountMax = Number.isFinite(amountMax);
+    const amountMinRaw = quickFilters.amountMin.trim();
+    const amountMaxRaw = quickFilters.amountMax.trim();
+    const amountMin = Number(amountMinRaw);
+    const amountMax = Number(amountMaxRaw);
+    /**
+     * 根因说明：
+     * Number('') === 0，之前在“金额筛选框留空”时被误判为有效条件，
+     * 导致列表隐式追加“金额必须等于 0”，于是出现“交易记录为空”。
+     */
+    const hasAmountMin = amountMinRaw.length > 0 && Number.isFinite(amountMin);
+    const hasAmountMax = amountMaxRaw.length > 0 && Number.isFinite(amountMax);
     const tagsFilter = quickFilters.tags.trim().toLowerCase();
     const merchantFilter = quickFilters.merchant.trim().toLowerCase();
     const orderNoFilter = quickFilters.orderNo.trim().toLowerCase();

--- a/src/shared/lib/backup.ts
+++ b/src/shared/lib/backup.ts
@@ -115,15 +115,19 @@ export function loadWebdavConfig(): BackupWebdavConfig {
 }
 
 function joinWebdavPath(endpoint: string, remoteFilePath: string): string {
-  const base = endpoint.replace(/\/+$/, '');
+  // 允许把 endpoint 配成相对路径（如 /api/webdav），以便走同源反向代理绕过浏览器 CORS 限制。
+  const base = endpoint.trim().replace(/\/+$/, '');
   const path = remoteFilePath.replace(/^\/+/, '');
   return `${base}/${path}`;
 }
 
 function normalizeWebdavError(action: '上传' | '下载' | '创建目录', error: unknown): Error {
   if (error instanceof Error) {
-    if (error.message.includes('Failed to fetch')) {
-      return new Error(`WebDAV ${action}失败：网络连接或跨域(CORS)被拦截，请检查地址与服务端配置`);
+    if (error.message.includes('Failed to fetch') || error.name === 'TypeError') {
+      return new Error(
+        `WebDAV ${action}失败：请求被浏览器拦截（常见于跨域 CORS / HTTPS 混合内容）。` +
+          `可尝试将 endpoint 改为同源代理地址（例如 /api/webdav）并在服务端转发到真实 WebDAV。`
+      );
     }
     return error;
   }


### PR DESCRIPTION
### Motivation

- 修复用户在交易页看到“暂无交易记录”的异常情况，排查到是快速金额筛选把空字符串算作 `0` 导致误筛空列表。 
- 改善 WebDAV 同步在浏览器被拦截时的错误提示与使用引导，以便用户采用同源代理绕过 CORS 问题。 
- 优化汇率计算器的键盘布局，使 `0` 键横跨两列以符合常见计算器习惯并提升可用性。

### Description

- 在 `src/pages/transactions/TransactionsPage.tsx` 中改为先判断金额筛选输入是否为空再使用 `Number(...)` 并补充了根因注释，避免 `Number('') === 0` 导致误筛空列表。 
- 在 `src/shared/lib/backup.ts` 中允许 `endpoint` 使用相对路径（并加注释），并增强 `normalizeWebdavError` 的归一化文案以明确提示 CORS / 混合内容等浏览器拦截场景以及建议使用同源代理。 
- 在 `src/pages/database-settings/DatabaseSettingsPage.tsx` 的 WebDAV 配置区增加提示文案，指导用户改用同源代理（例如 `/api/webdav`）。 
- 在 `src/features/exchange/ui/ExchangeConverter.tsx` 与 `src/app/styles/global.css` 中调整计算器：给 `0` 键增加 `exchange-key-zero` 样式并设置为横跨两列以优化布局。 

### Testing

- Ran unit tests with `npm run test` (Vitest), all tests passed. 
- Ran build with `npm run build`, build completed successfully. 
- Ran lint with `npm run lint`, lint failed due to an existing repository warning unrelated to these changes (a pre-existing React hook dependency warning in `AssistantPage.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69901436bbec8331b077154d41863e79)