### PR TITLE
feat(import): 支持微信 XLSX 账单导入并兼容重复表头字段

### DIFF
--- a/src/pages/database-settings/DatabaseSettingsPage.tsx
+++ b/src/pages/database-settings/DatabaseSettingsPage.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, useMemo, useRef, useState } from 'react';
 import {
   applyBillImportMode,
   BillImportMode,
-  parseBillCsvToTransactions
+  parseBillFileToTransactions
 } from '../../shared/lib/billImport';
 import {
   BackupWebdavConfig,
@@ -98,10 +98,9 @@ export function DatabaseSettingsPage() {
     }
 
     try {
-      const csvText = await file.text();
       const refs = ensureDefaultRefs();
-      const rows = parseBillCsvToTransactions({
-        csvText,
+      const rows = await parseBillFileToTransactions({
+        file,
         source,
         defaultCategoryId: refs.categoryId,
         defaultAccountId: refs.accountId
@@ -136,7 +135,7 @@ export function DatabaseSettingsPage() {
         'success'
       );
     } catch {
-      showToast('账单导入失败：CSV 解析异常', 'error');
+      showToast('账单导入失败：文件解析异常', 'error');
     }
   };
 
@@ -197,7 +196,7 @@ export function DatabaseSettingsPage() {
         <p>已移除 MySQL / PostgreSQL / Redis 连接配置，当前统一使用备份与恢复方案。</p>
         <ul style={{ marginTop: 10, color: 'var(--color-text-secondary)', lineHeight: 1.7 }}>
           <li>支持本地 JSON 一键导出与导入。</li>
-          <li>支持导入微信 / 支付宝账单 CSV。</li>
+          <li>支持导入微信 / 支付宝账单 CSV / XLSX。</li>
           <li>支持 WebDAV 远程同步（上传与下载恢复）。</li>
         </ul>
       </section>
@@ -225,8 +224,8 @@ export function DatabaseSettingsPage() {
       </section>
 
       <section className="panel" style={{ marginTop: 12 }}>
-        <h3 style={{ marginTop: 0 }}>账单 CSV 导入</h3>
-        <p className="sync-tip">支持微信、支付宝官方账单 CSV / TXT（含制表符）格式。</p>
+        <h3 style={{ marginTop: 0 }}>账单导入</h3>
+        <p className="sync-tip">支持微信、支付宝官方账单 CSV / TXT（含制表符）与微信 XLSX 格式。</p>
         <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
           <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
             导入模式
@@ -261,9 +260,9 @@ export function DatabaseSettingsPage() {
           <input
             ref={billInputRef}
             type="file"
-            title="导入账单 CSV"
-            aria-label="导入账单 CSV"
-            accept=".csv,text/csv,.txt,text/plain"
+            title="导入账单文件"
+            aria-label="导入账单文件"
+            accept=".csv,text/csv,.txt,text/plain,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             style={{ display: 'none' }}
             onChange={handleImportBillFile}
           />

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -7,7 +7,7 @@ import { exportTransactionsCsv } from '../../shared/lib/csv';
 import {
   applyBillImportMode,
   BillImportMode,
-  parseBillCsvToTransactions
+  parseBillFileToTransactions
 } from '../../shared/lib/billImport';
 import { formatDate } from '../../shared/lib/format';
 import { Toast, ToastVariant } from '../../shared/ui/Toast';
@@ -195,31 +195,6 @@ function resolveImportedCategoryId(
   }
 
   return fallbackCategoryId;
-}
-
-/**
- * 兼容账单文件常见编码：
- * - 优先 UTF-8
- * - 若出现乱码，再尝试 GB18030（覆盖 GBK/GB2312）
- */
-function decodeBillFileText(file: File): Promise<string> {
-  return file.arrayBuffer().then((buffer) => {
-    const utf8 = new TextDecoder('utf-8').decode(buffer);
-    if (/交易|金额|收\/支|交易时间|交易创建时间/.test(utf8) && !utf8.includes('�')) {
-      return utf8;
-    }
-
-    try {
-      const gbText = new TextDecoder('gb18030').decode(buffer);
-      if (/交易|金额|收\/支|交易时间|交易创建时间/.test(gbText)) {
-        return gbText;
-      }
-    } catch {
-      // ignore unsupported encoding
-    }
-
-    return utf8;
-  });
 }
 
 function detectSource(
@@ -639,7 +614,6 @@ export function TransactionsPage() {
     }
 
     try {
-      const csvText = await decodeBillFileText(file);
       const defaultCategoryId = categories[0]?.id;
       const defaultAccountId = accounts[0]?.id;
 
@@ -650,8 +624,8 @@ export function TransactionsPage() {
         return;
       }
 
-      const parsed = parseBillCsvToTransactions({
-        csvText,
+      const parsed = await parseBillFileToTransactions({
+        file,
         source: activeSource,
         defaultCategoryId,
         defaultAccountId
@@ -967,7 +941,7 @@ export function TransactionsPage() {
       <input
         ref={fileInputRef}
         type="file"
-        accept=".csv,text/csv"
+        accept=".csv,text/csv,.txt,text/plain,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         style={{ display: 'none' }}
         onChange={(event) => void handleImportFile(event)}
       />

--- a/src/shared/lib/billImport.test.ts
+++ b/src/shared/lib/billImport.test.ts
@@ -46,4 +46,26 @@ describe('parseBillCsvToTransactions', () => {
     expect(rows[0].merchantOrderNo).toBe('M20260210');
     expect(rows[0].amount).toBe(9.99);
   });
+
+  it('应合并重复标题栏字段并保留完整信息', () => {
+    const csvText = [
+      '微信支付账单明细',
+      '交易时间,交易类型,交易类型,交易对方,商品,收/支,金额(元),当前状态,交易单号,商户单号,备注',
+      '2026-02-14 18:46:47,转账,微信零钱转账,666,转账备注:微信转账,支出,¥65.00,对方已收钱,53010002489226202602144159140074,1000050001202602140030491809117,/'
+    ].join('\n');
+
+    const rows = parseBillCsvToTransactions({
+      csvText,
+      source: 'wechat',
+      defaultCategoryId: 'cat-default',
+      defaultAccountId: 'acc-default'
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe('expense');
+    expect(rows[0].amount).toBe(65);
+    expect(rows[0].note).toContain('666');
+    expect(rows[0].orderNo).toBe('53010002489226202602144159140074');
+    expect(rows[0].merchantOrderNo).toBe('1000050001202602140030491809117');
+  });
 });

--- a/src/shared/lib/billImport.ts
+++ b/src/shared/lib/billImport.ts
@@ -9,6 +9,13 @@ interface ParseBillInput {
   defaultAccountId: string;
 }
 
+interface ParseBillFileInput {
+  file: File;
+  source: BillSource;
+  defaultCategoryId: string;
+  defaultAccountId: string;
+}
+
 export type BillImportMode = 'incremental' | 'merge' | 'overwrite';
 
 interface ApplyBillImportModeInput {
@@ -37,8 +44,8 @@ const AMOUNT_KEYS = ['金额', '金额(元)', '金额（元）', '订单金额',
 const TYPE_KEYS = ['收/支', '收支类型', '交易类型', '资金类型', '类型'];
 const NOTE_KEYS = ['商品名称', '商品', '商品说明', '交易对方', '备注', '商户', '收款方'];
 const STATUS_KEYS = ['交易状态', '当前状态', '状态'];
-const ORDER_NO_KEYS = ['交易号', '交易订单号', '订单号'];
-const MERCHANT_ORDER_NO_KEYS = ['商家订单号', '商户订单号'];
+const ORDER_NO_KEYS = ['交易号', '交易订单号', '订单号', '交易单号'];
+const MERCHANT_ORDER_NO_KEYS = ['商家订单号', '商户订单号', '商户单号'];
 
 const HEADER_HINT_KEYS = [
   ...DATE_KEYS,
@@ -109,6 +116,25 @@ function pickByKeys(row: Record<string, string>, keys: string[]): string {
     }
   }
   return '';
+}
+
+function mergeRowCell(row: Record<string, string>, key: string, value: string): void {
+  if (!key) return;
+  if (!(key in row)) {
+    row[key] = value;
+    return;
+  }
+
+  const prev = row[key].trim();
+  const next = value.trim();
+  if (!prev && next) {
+    row[key] = value;
+    return;
+  }
+
+  if (prev && next && prev !== next) {
+    row[key] = `${prev} ${next}`;
+  }
 }
 
 function parseAmount(raw: string): number {
@@ -352,9 +378,7 @@ export function parseBillCsvToTransactions(input: ParseBillInput): Omit<Transact
 
     const row: Record<string, string> = {};
     headers.forEach((h, idx) => {
-      if (h) {
-        row[h] = cols[idx] ?? '';
-      }
+      mergeRowCell(row, h, cols[idx] ?? '');
     });
 
     if (shouldSkipByStatus(row)) {
@@ -388,4 +412,171 @@ export function parseBillCsvToTransactions(input: ParseBillInput): Omit<Transact
   }
 
   return result;
+}
+
+function cellRefToColIndex(cellRef: string): number {
+  const letters = cellRef.replace(/[0-9]/g, '').toUpperCase();
+  let result = 0;
+  for (let i = 0; i < letters.length; i++) {
+    result = result * 26 + (letters.charCodeAt(i) - 64);
+  }
+  return Math.max(0, result - 1);
+}
+
+async function inflateRaw(data: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream === 'undefined') {
+    throw new Error('当前环境不支持 XLSX 解压');
+  }
+
+  const stream = new Blob([data]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
+  const buffer = await new Response(stream).arrayBuffer();
+  return new Uint8Array(buffer);
+}
+
+async function unzipXlsxEntries(buffer: ArrayBuffer): Promise<Map<string, Uint8Array>> {
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+  const files = new Map<string, Uint8Array>();
+
+  let eocdOffset = -1;
+  for (let i = bytes.length - 22; i >= Math.max(0, bytes.length - 65536); i--) {
+    if (view.getUint32(i, true) === 0x06054b50) {
+      eocdOffset = i;
+      break;
+    }
+  }
+
+  if (eocdOffset < 0) {
+    throw new Error('无效的 XLSX 文件');
+  }
+
+  const centralOffset = view.getUint32(eocdOffset + 16, true);
+  const totalEntries = view.getUint16(eocdOffset + 10, true);
+  const decoder = new TextDecoder();
+
+  let ptr = centralOffset;
+  for (let i = 0; i < totalEntries; i++) {
+    if (view.getUint32(ptr, true) !== 0x02014b50) {
+      throw new Error('XLSX 中央目录损坏');
+    }
+
+    const compression = view.getUint16(ptr + 10, true);
+    const compressedSize = view.getUint32(ptr + 20, true);
+    const fileNameLen = view.getUint16(ptr + 28, true);
+    const extraLen = view.getUint16(ptr + 30, true);
+    const commentLen = view.getUint16(ptr + 32, true);
+    const localHeaderOffset = view.getUint32(ptr + 42, true);
+    const fileName = decoder.decode(bytes.slice(ptr + 46, ptr + 46 + fileNameLen));
+
+    const localSig = view.getUint32(localHeaderOffset, true);
+    if (localSig !== 0x04034b50) {
+      throw new Error('XLSX 本地文件头损坏');
+    }
+
+    const localNameLen = view.getUint16(localHeaderOffset + 26, true);
+    const localExtraLen = view.getUint16(localHeaderOffset + 28, true);
+    const dataStart = localHeaderOffset + 30 + localNameLen + localExtraLen;
+    const compressed = bytes.slice(dataStart, dataStart + compressedSize);
+
+    if (compression === 0) {
+      files.set(fileName, compressed);
+    } else if (compression === 8) {
+      files.set(fileName, await inflateRaw(compressed));
+    }
+
+    ptr += 46 + fileNameLen + extraLen + commentLen;
+  }
+
+  return files;
+}
+
+function extractSharedStrings(sharedXml: string): string[] {
+  const doc = new DOMParser().parseFromString(sharedXml, 'application/xml');
+  return Array.from(doc.getElementsByTagName('si')).map((node) => {
+    const richTexts = Array.from(node.getElementsByTagName('t')).map((t) => t.textContent || '');
+    return richTexts.join('');
+  });
+}
+
+function extractSheetRows(sheetXml: string, sharedStrings: string[]): string[][] {
+  const doc = new DOMParser().parseFromString(sheetXml, 'application/xml');
+  const rows = Array.from(doc.getElementsByTagName('row'));
+  return rows.map((row) => {
+    const cells = Array.from(row.getElementsByTagName('c'));
+    const values: string[] = [];
+
+    cells.forEach((cell) => {
+      const ref = cell.getAttribute('r') || '';
+      const idx = ref ? cellRefToColIndex(ref) : values.length;
+      const cellType = cell.getAttribute('t');
+      const v = cell.getElementsByTagName('v')[0]?.textContent || '';
+      const inline = cell.getElementsByTagName('is')[0]?.textContent || '';
+      let text = inline || v;
+      if (cellType === 's') {
+        text = sharedStrings[Number.parseInt(v, 10)] || '';
+      }
+      values[idx] = String(text).trim();
+    });
+
+    return values.map((v) => v || '');
+  });
+}
+
+async function xlsxToDelimitedText(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  const entries = await unzipXlsxEntries(buffer);
+  const decoder = new TextDecoder('utf-8');
+
+  const sharedXml = entries.get('xl/sharedStrings.xml');
+  const sharedStrings = sharedXml ? extractSharedStrings(decoder.decode(sharedXml)) : [];
+
+  const sheetEntry =
+    entries.get('xl/worksheets/sheet1.xml') ||
+    Array.from(entries.entries()).find(([name]) =>
+      /^xl\/worksheets\/sheet\d+\.xml$/.test(name)
+    )?.[1];
+
+  if (!sheetEntry) {
+    throw new Error('XLSX 未找到工作表');
+  }
+
+  const rows = extractSheetRows(decoder.decode(sheetEntry), sharedStrings);
+  return rows
+    .map((row) => row.map((cell) => String(cell || '').replace(/\r?\n/g, ' ')).join('\t'))
+    .join('\n');
+}
+
+async function decodeBillFileText(file: File): Promise<string> {
+  if (/\.xlsx$/i.test(file.name)) {
+    return xlsxToDelimitedText(file);
+  }
+
+  const buffer = await file.arrayBuffer();
+  const utf8 = new TextDecoder('utf-8').decode(buffer);
+  if (/交易|金额|收\/支|交易时间|交易创建时间/.test(utf8) && !utf8.includes('�')) {
+    return utf8;
+  }
+
+  try {
+    const gbText = new TextDecoder('gb18030').decode(buffer);
+    if (/交易|金额|收\/支|交易时间|交易创建时间/.test(gbText)) {
+      return gbText;
+    }
+  } catch {
+    // ignore unsupported encoding
+  }
+
+  return utf8;
+}
+
+export async function parseBillFileToTransactions(
+  input: ParseBillFileInput
+): Promise<Omit<TransactionItem, 'id'>[]> {
+  const csvText = await decodeBillFileText(input.file);
+  return parseBillCsvToTransactions({
+    csvText,
+    source: input.source,
+    defaultCategoryId: input.defaultCategoryId,
+    defaultAccountId: input.defaultAccountId
+  });
 }


### PR DESCRIPTION
### Motivation
- 微信导出的账单有时为 XLSX 且会出现重复的“类型/交易类型”等列，需按重复类型标题栏合并字段以保留完整信息并与支付宝 CSV 导入兼容。 
- 不改变现有交易实体与导入模式逻辑，尽量复用现有 CSV 解析与去重/合并流程以降低回归风险。

### Description
- 新增文件级解析入口 `parseBillFileToTransactions`，统一处理文件 -> 文本 -> 现有 CSV 解析的流程，保持后端映射不变。 
- 增加对 `xlsx` 的原生解析实现（从 ZIP 中读取 `xl/sharedStrings.xml` 与 `xl/worksheets/*.xml` 并转为分隔文本），并在无法使用外部库时在浏览器端解压/解析。 
- 为解决微信导出中的重复表头，新增 `mergeRowCell` 合并逻辑：遇到相同表头则拼接非空且不同的值，避免后列覆盖前列内容。 
- 扩展识别关键词（增加 `交易单号` / `商户单号`）以兼容微信字段命名，同时将 `TransactionsPage` 与 `DatabaseSettingsPage` 的文件选择 `accept` 扩展到 `.xlsx`，并切换到新解析接口。 
- 新增单测覆盖“重复标题栏合并”场景，保持支付宝 CSV 的现有单测不变。 

### Testing
- 运行 `npm run lint`：通过。 
- 运行单测 `npm run test -- src/shared/lib/billImport.test.ts`：所有用例通过（包含新增的“重复标题栏合并”测试）。 
- 运行构建 `npm run build`：构建通过，产物成功生成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69907bcc88c08331b8e49791e1c7f395)