### PR TITLE
feat(transactions): 支持批量编辑分类/账户并修复导入账户来源匹配

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -994,6 +994,26 @@ tr:hover td {
   background: var(--color-bg-subtle);
 }
 
+.transaction-bulk-actions {
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.transaction-bulk-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-xs);
+  color: var(--color-text-secondary);
+}
+
+.transaction-bulk-select span {
+  white-space: nowrap;
+}
+
+.transaction-bulk-select select {
+  min-width: 120px;
+}
 .transaction-columns-panel {
   margin-bottom: var(--space-3);
   padding: var(--space-3);

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -92,6 +92,10 @@ interface TransactionTableProps {
   onOpenDetail: (id: string) => void;
   onDelete: (id: string) => void;
   onDeleteSelected: () => void;
+  onBulkEditCategory: (categoryId: string) => void;
+  onBulkEditAccount: (accountId: string) => void;
+  categoryOptions: Array<{ id: string; name: string }>;
+  accountOptions: Array<{ id: string; name: string }>;
   onClearSelection: () => void;
   onToggleSelect: (id: string, selected: boolean) => void;
   onToggleSelectPage: (selected: boolean) => void;
@@ -133,6 +137,10 @@ export function TransactionTable({
   onOpenDetail,
   onDelete,
   onDeleteSelected,
+  onBulkEditCategory,
+  onBulkEditAccount,
+  categoryOptions,
+  accountOptions,
   onClearSelection,
   onToggleSelect,
   onToggleSelectPage,
@@ -267,7 +275,43 @@ export function TransactionTable({
           {selectedIds.length > 0 ? (
             <div className="transaction-bulk-bar">
               <strong>已选中 {selectedIds.length} 条</strong>
-              <div className="row">
+              <div className="row transaction-bulk-actions">
+                <label className="transaction-bulk-select">
+                  <span>批量分类</span>
+                  <select
+                    defaultValue=""
+                    onChange={(event) => {
+                      if (!event.target.value) return;
+                      onBulkEditCategory(event.target.value);
+                      event.target.value = '';
+                    }}
+                  >
+                    <option value="">选择分类</option>
+                    {categoryOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="transaction-bulk-select">
+                  <span>批量账户</span>
+                  <select
+                    defaultValue=""
+                    onChange={(event) => {
+                      if (!event.target.value) return;
+                      onBulkEditAccount(event.target.value);
+                      event.target.value = '';
+                    }}
+                  >
+                    <option value="">选择账户</option>
+                    {accountOptions.map((option) => (
+                      <option key={option.id} value={option.id}>
+                        {option.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
                 <button type="button" onClick={onDeleteSelected} className="danger">
                   批量删除
                 </button>

--- a/src/pages/database-settings/DatabaseSettingsPage.tsx
+++ b/src/pages/database-settings/DatabaseSettingsPage.tsx
@@ -4,6 +4,7 @@ import {
   BillImportMode,
   parseBillFileToTransactions
 } from '../../shared/lib/billImport';
+import { resolveImportDefaultAccountId } from '../../shared/lib/importAccount';
 import {
   BackupWebdavConfig,
   createFinanceBackupPayload,
@@ -55,9 +56,12 @@ export function DatabaseSettingsPage() {
     setToast({ visible: true, message, variant });
   };
 
-  const ensureDefaultRefs = () => {
+  const ensureDefaultRefs = (source?: BillSource) => {
     const categoryId = categories[0]?.id || addCategory('默认分类');
-    const accountId = accounts[0]?.id || addAccount('默认账户', undefined, 0);
+    const fallbackAccountId = accounts[0]?.id || addAccount('默认账户', undefined, 0);
+    const accountId = source
+      ? resolveImportDefaultAccountId(accounts, source, fallbackAccountId)
+      : fallbackAccountId;
     return { categoryId, accountId };
   };
 
@@ -98,7 +102,7 @@ export function DatabaseSettingsPage() {
     }
 
     try {
-      const refs = ensureDefaultRefs();
+      const refs = ensureDefaultRefs(source);
       const rows = await parseBillFileToTransactions({
         file,
         source,

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -10,6 +10,7 @@ import {
   parseBillFileToTransactions
 } from '../../shared/lib/billImport';
 import { formatDate } from '../../shared/lib/format';
+import { resolveImportDefaultAccountId } from '../../shared/lib/importAccount';
 import { Toast, ToastVariant } from '../../shared/ui/Toast';
 import { ConfirmDialog } from '../../shared/ui/ConfirmDialog';
 import {
@@ -615,7 +616,12 @@ export function TransactionsPage() {
 
     try {
       const defaultCategoryId = categories[0]?.id;
-      const defaultAccountId = accounts[0]?.id;
+      const fallbackAccountId = accounts[0]?.id;
+      const defaultAccountId = resolveImportDefaultAccountId(
+        accounts,
+        activeSource,
+        fallbackAccountId
+      );
 
       if (!defaultCategoryId || !defaultAccountId) {
         const message = '导入失败：请先创建分类和账户。';
@@ -749,6 +755,46 @@ export function TransactionsPage() {
       return;
     }
     setPendingDeleteIds(selectedIds);
+  };
+
+  const applyBulkUpdate = (payload: { categoryId?: string; accountId?: string }) => {
+    if (selectedIds.length === 0) {
+      return;
+    }
+
+    let changed = 0;
+    selectedIds.forEach((id) => {
+      const tx = transactions.find((item) => item.id === id);
+      if (!tx) return;
+
+      const nextCategoryId = payload.categoryId ?? tx.categoryId;
+      const nextAccountId = payload.accountId ?? tx.accountId;
+      if (nextCategoryId === tx.categoryId && nextAccountId === tx.accountId) {
+        return;
+      }
+
+      updateTransaction(id, {
+        ...tx,
+        categoryId: nextCategoryId,
+        accountId: nextAccountId
+      });
+      changed += 1;
+    });
+
+    if (changed > 0) {
+      const changedLabel = [payload.categoryId ? '分类' : '', payload.accountId ? '账户' : '']
+        .filter(Boolean)
+        .join('和');
+      showToast(`已批量更新 ${changed} 条交易的${changedLabel}。`, 'success');
+    }
+  };
+
+  const handleBulkEditCategory = (categoryId: string) => {
+    applyBulkUpdate({ categoryId });
+  };
+
+  const handleBulkEditAccount = (accountId: string) => {
+    applyBulkUpdate({ accountId });
   };
 
   const hasQuickFilters =
@@ -978,6 +1024,10 @@ export function TransactionsPage() {
         allPageSelected={allPageSelected}
         onDelete={(id) => setPendingDeleteIds([id])}
         onDeleteSelected={handleDeleteSelected}
+        onBulkEditCategory={handleBulkEditCategory}
+        onBulkEditAccount={handleBulkEditAccount}
+        categoryOptions={categories.map((item) => ({ id: item.id, name: item.name }))}
+        accountOptions={accounts.map((item) => ({ id: item.id, name: item.name }))}
         onClearSelection={() => setSelectedIds([])}
         onToggleSelect={handleToggleSelect}
         onToggleSelectPage={handleToggleSelectPage}

--- a/src/shared/lib/importAccount.test.ts
+++ b/src/shared/lib/importAccount.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { resolveImportDefaultAccountId } from './importAccount';
+
+describe('resolveImportDefaultAccountId', () => {
+  it('微信导入时优先匹配微信账户', () => {
+    const accountId = resolveImportDefaultAccountId(
+      [
+        { id: 'acc-alipay', name: '支付宝' },
+        { id: 'acc-wechat', name: '微信钱包' }
+      ],
+      'wechat',
+      'acc-alipay'
+    );
+
+    expect(accountId).toBe('acc-wechat');
+  });
+
+  it('支付宝导入时优先匹配支付宝账户', () => {
+    const accountId = resolveImportDefaultAccountId(
+      [
+        { id: 'acc-wechat', name: '微信' },
+        { id: 'acc-alipay', name: '支付宝余额' }
+      ],
+      'alipay'
+    );
+
+    expect(accountId).toBe('acc-alipay');
+  });
+
+  it('未匹配到账户时回落到fallback', () => {
+    const accountId = resolveImportDefaultAccountId(
+      [{ id: 'acc-card', name: '招商银行' }],
+      'wechat',
+      'acc-card'
+    );
+
+    expect(accountId).toBe('acc-card');
+  });
+});

--- a/src/shared/lib/importAccount.ts
+++ b/src/shared/lib/importAccount.ts
@@ -1,0 +1,25 @@
+import { Account } from '../../entities/account/types';
+
+type BillSource = 'wechat' | 'alipay';
+
+const SOURCE_PATTERNS: Record<BillSource, RegExp> = {
+  wechat: /微信|wechat|wx/i,
+  alipay: /支付宝|alipay|余额宝|蚂蚁/i
+};
+
+export function resolveImportDefaultAccountId(
+  accounts: Account[],
+  source: BillSource,
+  fallbackAccountId?: string
+): string {
+  const directHit = accounts.find((item) => SOURCE_PATTERNS[source].test(item.name));
+  if (directHit) {
+    return directHit.id;
+  }
+
+  if (fallbackAccountId) {
+    return fallbackAccountId;
+  }
+
+  return accounts[0]?.id || '';
+}


### PR DESCRIPTION
### Motivation
- 为了让用户能对多条选中的账单一次性修改分类或账户，新增批量编辑操作以减少重复操作成本。 
- 修复导入账单时默认账户分配的错误行为，使微信/支付宝导入能优先匹配对应来源账户，避免误分配到不匹配的账户。 

### Description
- 在 `TransactionTable` 中新增批量编辑 UI 并扩展 props（`onBulkEditCategory`、`onBulkEditAccount`、`categoryOptions`、`accountOptions`），在多选工具栏中添加“批量分类/批量账户”下拉。 
- 在 `TransactionsPage` 中实现 `applyBulkUpdate`、`handleBulkEditCategory` 和 `handleBulkEditAccount`，对选中交易逐条执行 `updateTransaction` 并通过 `showToast` 给出操作反馈，同时将分类/账户列表透传给表格组件。 
- 新增 `src/shared/lib/importAccount.ts` 中的 `resolveImportDefaultAccountId`，按来源关键词优先匹配已有账户并在无匹配时回退到传入的 fallback 或首个账户；并在交易导入流程和数据库设置页导入流程中使用该函数以保证来源与账户一致。 
- 增加样式调整以支持批量操作区布局（`src/app/styles/global.css`）。 
- 新增单元测试 `src/shared/lib/importAccount.test.ts` 覆盖来源匹配与回退场景。 

### Testing
- 运行单元测试：`npm run test -- src/shared/lib/billImport.test.ts src/shared/lib/importAccount.test.ts`，所有测试通过（2 个测试文件，6 个测试用例均通过）。 
- 运行生产构建：`npm run build`，构建成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990806ec83c833184ba4d005ac14fbc)