### PR TITLE
feat: 分类管理显示交易数量并支持快捷查看

### DIFF
--- a/src/pages/categories-accounts/CategoriesAccountsPage.tsx
+++ b/src/pages/categories-accounts/CategoriesAccountsPage.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useFinanceStore } from '../../shared/store/useFinanceStore';
 import { formatCurrencyFixed2 } from '../../shared/lib/format';
 import { EmptyState } from '../../shared/ui/EmptyState';
@@ -19,6 +20,7 @@ function isValidName(name: string) {
 }
 
 export function CategoriesAccountsPage() {
+  const navigate = useNavigate();
   const categories = useFinanceStore((s) => s.categories);
   const accounts = useFinanceStore((s) => s.accounts);
   const transactions = useFinanceStore((s) => s.transactions);
@@ -115,6 +117,15 @@ export function CategoriesAccountsPage() {
     () => (showAllCategories ? categories : categories.slice(0, CATEGORY_COLLAPSE_THRESHOLD)),
     [categories, showAllCategories]
   );
+
+  const categoryUsageMap = useMemo(() => {
+    const map = new Map<string, number>();
+    transactions.forEach((tx) => {
+      const prev = map.get(tx.categoryId) || 0;
+      map.set(tx.categoryId, prev + 1);
+    });
+    return map;
+  }, [transactions]);
 
   const displayTags = useMemo(
     () => (showAllTags ? tagGroups : tagGroups.slice(0, TAG_COLLAPSE_THRESHOLD)),
@@ -248,8 +259,21 @@ export function CategoriesAccountsPage() {
             <ul className="categories-list">
               {displayCategories.map((item) => (
                 <li key={item.id} className="row categories-row">
-                  <span style={{ flex: 1 }}>{item.name}</span>
-                  <button className="danger" onClick={() => removeCategory(item.id)}>
+                  <span style={{ flex: 1 }}>
+                    {item.name}
+                    <small className="tag-count-chip">
+                      {categoryUsageMap.get(item.id) || 0} 条
+                    </small>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      navigate(`/transactions?categoryId=${encodeURIComponent(item.id)}`)
+                    }
+                  >
+                    快捷查看
+                  </button>
+                  <button type="button" className="danger" onClick={() => removeCategory(item.id)}>
                     删除
                   </button>
                 </li>

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -415,6 +415,23 @@ export function TransactionsPage() {
   }, [columnWidths]);
 
   useEffect(() => {
+    const categoryId = searchParams.get('categoryId') ?? '';
+    if (!categoryId) {
+      return;
+    }
+
+    const matchedCategory = categories.find((item) => item.id === categoryId);
+    if (!matchedCategory) {
+      return;
+    }
+
+    setQuickFilters((prev) =>
+      prev.category === matchedCategory.name ? prev : { ...prev, category: matchedCategory.name }
+    );
+    setPage(1);
+  }, [categories, searchParams, setPage]);
+
+  useEffect(() => {
     const highlight = searchParams.get('highlight') ?? '';
     if (!highlight) {
       return;


### PR DESCRIPTION
### Motivation
- 在“分类与标签管理”里直观显示每个分类被使用的交易条数，便于用户了解分类活跃度并快速定位相关交易。
- 支持从分类管理一键跳转到交易列表并自动应用分类筛选，提高查看效率。 

### Description
- 在 `CategoriesAccountsPage` 中新增 `categoryUsageMap`，基于 `transactions` 聚合每个 `categoryId` 的交易数量并在列表中显示为 `x 条`。
- 为每个分类增加“快捷查看”按钮，点击时使用 `useNavigate` 跳转到 `/transactions?categoryId=...` 带上查询参数。 
- 在 `TransactionsPage` 中新增 `useEffect`，读取 URL 的 `categoryId` 参数并将快速筛选的 `category` 字段设为对应分类名称，同时将分页重置到第 1 页。 
- 修改的文件：`src/pages/categories-accounts/CategoriesAccountsPage.tsx`，`src/pages/transactions/TransactionsPage.tsx`。 

### Testing
- 运行 `npm run lint`，静态检查通过（无错误）。
- 运行 `npm run test`，所有自动化测试通过（Vitest 全部通过）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699123934e248331a37a4ee24c46a1b0)