### PR TITLE
fix(assistant): auto-scroll when assistant replies

### DIFF
--- a/src/pages/assistant/AssistantPage.tsx
+++ b/src/pages/assistant/AssistantPage.tsx
@@ -327,6 +327,13 @@ export function AssistantPage() {
     messageEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
   }, [wb.status, wb.rawContent, wb.rawReasoning, wb.entries.length, wb.error]);
 
+  // 当 AI 助手/AI 记账收到新的助手回复时，始终自动滚到底部。
+  useEffect(() => {
+    const latestMessage = chatHistory[chatHistory.length - 1];
+    if (!latestMessage || latestMessage.role !== 'assistant') return;
+    messageEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [chatHistory, mode]);
+
   const appendMessageToMode = useCallback(
     (targetMode: AssistantMode, message: ChatHistoryItem) => {
       if (targetMode === mode) {


### PR DESCRIPTION
### Motivation
- Ensure the chat view automatically scrolls to the bottom whenever the AI (assistant or bookkeeping mode) posts a reply so users always see new assistant responses.

### Description
- Add a dedicated `useEffect` in `src/pages/assistant/AssistantPage.tsx` that watches `chatHistory` and calls `messageEndRef.current?.scrollIntoView()` whenever the latest message has `role === 'assistant'`, while keeping the existing status-based scrolling intact.

### Testing
- Ran `npm run lint -- src/pages/assistant/AssistantPage.tsx` which succeeded.
- Ran full test suite with `npm run test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699126a08b848331b2c2dcf004a1d67a)