### PR TITLE
feat(finance): 支持 RSS 资讯订阅与阅读

### DIFF
--- a/src/pages/finance/FinancePage.tsx
+++ b/src/pages/finance/FinancePage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useAppPreferences } from '../../shared/store/useAppPreferences';
 
 type FinanceNewsItem = {
   id: string;
@@ -6,6 +7,7 @@ type FinanceNewsItem = {
   source: string;
   link: string;
   publishedAt: string;
+  summary?: string;
 };
 
 const FALLBACK_NEWS: FinanceNewsItem[] = [
@@ -14,21 +16,24 @@ const FALLBACK_NEWS: FinanceNewsItem[] = [
     title: '央行公开市场操作保持流动性合理充裕，短端利率维持平稳',
     source: '宏观观察',
     link: 'https://www.gov.cn/',
-    publishedAt: '今日'
+    publishedAt: '今日',
+    summary: '关注流动性投放节奏与短端利率变化，利于理解市场风险偏好。'
   },
   {
     id: 'fallback-2',
     title: '多家机构上调全年 GDP 增速预测，消费修复成为核心变量',
     source: '机构研报摘要',
     link: 'https://www.stats.gov.cn/',
-    publishedAt: '今日'
+    publishedAt: '今日',
+    summary: '观察社零、就业与居民信心等指标是否持续共振，避免只看单一数据。'
   },
   {
     id: 'fallback-3',
     title: '黄金与原油波动加剧，资产配置更强调分散化与现金流质量',
     source: '资产配置周报',
     link: 'https://www.safe.gov.cn/',
-    publishedAt: '本周'
+    publishedAt: '本周',
+    summary: '在高波动阶段保持仓位纪律与流动性缓冲，优先保证家庭现金流稳定。'
   }
 ];
 
@@ -53,10 +58,85 @@ function formatTimeLabel(value?: string): string {
   }).format(date);
 }
 
+function cleanHtml(raw?: string | null): string {
+  return String(raw || '')
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseRssItems(xmlText: string, fallbackSource: string): FinanceNewsItem[] {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlText, 'text/xml');
+  const parserError = doc.querySelector('parsererror');
+  if (parserError) {
+    throw new Error('RSS 解析失败');
+  }
+
+  const sourceTitle =
+    cleanHtml(doc.querySelector('channel > title')?.textContent) ||
+    cleanHtml(doc.querySelector('feed > title')?.textContent) ||
+    fallbackSource;
+
+  const itemNodes = Array.from(doc.querySelectorAll('item, entry'));
+  return itemNodes
+    .map((node, index) => {
+      const title =
+        cleanHtml(node.querySelector('title')?.textContent) ||
+        cleanHtml(node.querySelector('media\\:title')?.textContent) ||
+        '未命名资讯';
+      const directLink = node.querySelector('link')?.textContent?.trim();
+      const atomLink =
+        (node.querySelector('link[rel="alternate"]') as Element | null)?.getAttribute('href') ||
+        node.querySelector('link')?.getAttribute('href');
+      const link = directLink || atomLink || 'https://news.google.com/';
+      const publishedRaw =
+        node.querySelector('pubDate')?.textContent ||
+        node.querySelector('published')?.textContent ||
+        node.querySelector('updated')?.textContent ||
+        '';
+      const summaryRaw =
+        node.querySelector('description')?.textContent ||
+        node.querySelector('summary')?.textContent ||
+        node.querySelector('content')?.textContent ||
+        '';
+      return {
+        id: `${fallbackSource}-${index}-${title}`,
+        title,
+        source: sourceTitle,
+        link,
+        publishedAt: formatTimeLabel(publishedRaw),
+        summary: cleanHtml(summaryRaw)
+      };
+    })
+    .filter((item) => item.title && item.link)
+    .slice(0, 8);
+}
+
+async function fetchRssFeed(feedUrl: string, signal: AbortSignal): Promise<FinanceNewsItem[]> {
+  const encodedUrl = encodeURIComponent(feedUrl);
+  const response = await fetch(`https://api.allorigins.win/raw?url=${encodedUrl}`, { signal });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const xmlText = await response.text();
+  return parseRssItems(xmlText, feedUrl);
+}
+
 export function FinancePage() {
+  const { rssSubscriptions, addRssSubscription, removeRssSubscription, toggleRssSubscription } =
+    useAppPreferences();
   const [news, setNews] = useState<FinanceNewsItem[]>(FALLBACK_NEWS);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [feedTitle, setFeedTitle] = useState('');
+  const [feedUrl, setFeedUrl] = useState('');
+  const [activeNewsId, setActiveNewsId] = useState('');
+
+  const enabledFeeds = useMemo(
+    () => rssSubscriptions.filter((item) => item.enabled),
+    [rssSubscriptions]
+  );
 
   useEffect(() => {
     const controller = new AbortController();
@@ -64,39 +144,42 @@ export function FinancePage() {
     async function loadFinanceNews() {
       setLoading(true);
       setError('');
-      try {
-        const response = await fetch(
-          'https://api.allorigins.win/raw?url=https://www.cnbeta.com/backend/getArticlesByEndless?type=all&page=1',
-          {
-            signal: controller.signal
-          }
-        );
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const payload = (await response.json()) as {
-          result?: {
-            list?: Array<{ article_id?: string; title?: string; url?: string; pub_time?: string }>;
-          };
-        };
-        const list = payload?.result?.list || [];
-        const mapped = list
-          .filter((item) => typeof item.title === 'string' && item.title.trim())
-          .slice(0, 8)
-          .map((item, index) => ({
-            id: item.article_id || `remote-${index}`,
-            title: item.title || '未命名资讯',
-            source: '实时资讯',
-            link: item.url ? `https://www.cnbeta.com${item.url}` : 'https://www.cnbeta.com/',
-            publishedAt: formatTimeLabel(item.pub_time)
-          }));
 
-        if (mapped.length > 0) {
-          setNews(mapped);
+      if (enabledFeeds.length === 0) {
+        setNews(FALLBACK_NEWS);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const loadedLists = await Promise.allSettled(
+          enabledFeeds.map((item) => fetchRssFeed(item.url, controller.signal))
+        );
+        const merged = loadedLists
+          .flatMap((result) => (result.status === 'fulfilled' ? result.value : []))
+          .slice(0, 20);
+
+        const sorted = [...merged].sort((a, b) => {
+          const aTime = Date.parse(a.publishedAt);
+          const bTime = Date.parse(b.publishedAt);
+          if (Number.isNaN(aTime) || Number.isNaN(bTime)) return 0;
+          return bTime - aTime;
+        });
+
+        if (sorted.length > 0) {
+          setNews(sorted);
+          setActiveNewsId((current) => current || sorted[0].id);
         } else {
           setNews(FALLBACK_NEWS);
+          setError('订阅源暂无可读内容，已展示内置财经资讯。');
+        }
+
+        if (loadedLists.every((result) => result.status === 'rejected')) {
+          setError('RSS 订阅源暂不可用，已切换到内置财经内容。');
         }
       } catch (err) {
         if ((err as Error).name !== 'AbortError') {
-          setError('实时资讯暂不可用，已切换到内置财经内容。');
+          setError('RSS 订阅源暂不可用，已切换到内置财经内容。');
           setNews(FALLBACK_NEWS);
         }
       } finally {
@@ -106,38 +189,126 @@ export function FinancePage() {
 
     loadFinanceNews();
     return () => controller.abort();
-  }, []);
+  }, [enabledFeeds]);
 
   const dailyIdea = useMemo(() => {
     const day = new Date().getDate();
     return FINANCE_IDEAS[day % FINANCE_IDEAS.length];
   }, []);
 
+  const activeNews = useMemo(
+    () => news.find((item) => item.id === activeNewsId) || news[0] || null,
+    [activeNewsId, news]
+  );
+
+  function onAddFeed(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const result = addRssSubscription({ title: feedTitle, url: feedUrl });
+    if (!result.ok) {
+      setError(result.reason || '新增 RSS 失败。');
+      return;
+    }
+    setFeedTitle('');
+    setFeedUrl('');
+  }
+
   return (
     <div className="page-stack">
       <section className="card">
         <h2 style={{ marginTop: 0 }}>📰 金融资讯</h2>
-        <p className="muted">给「杂项」增加一个能随手浏览的财经信息区，避免空闲时无内容可看。</p>
-        {loading ? <p className="muted">正在加载近期资讯...</p> : null}
+        <p className="muted">支持 RSS 订阅与阅读，便于按自己的信息源持续跟踪财经动态。</p>
+
+        <div className="card" style={{ padding: 12, marginBottom: 12 }}>
+          <h3 style={{ marginTop: 0 }}>RSS 订阅管理</h3>
+          <form onSubmit={onAddFeed} style={{ display: 'grid', gap: 8 }}>
+            <input
+              value={feedTitle}
+              onChange={(event) => setFeedTitle(event.target.value)}
+              placeholder="订阅名称（可选）"
+            />
+            <input
+              value={feedUrl}
+              onChange={(event) => setFeedUrl(event.target.value)}
+              placeholder="https://example.com/feed.xml"
+            />
+            <button type="submit">新增订阅</button>
+          </form>
+
+          <div style={{ marginTop: 10, display: 'grid', gap: 8 }}>
+            {rssSubscriptions.map((item) => (
+              <div
+                key={item.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 8,
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 8,
+                  padding: 8
+                }}
+              >
+                <div>
+                  <strong>{item.title}</strong>
+                  <p className="muted" style={{ margin: 0, fontSize: 12 }}>
+                    {item.url}
+                  </p>
+                </div>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button type="button" onClick={() => toggleRssSubscription(item.id)}>
+                    {item.enabled ? '停用' : '启用'}
+                  </button>
+                  <button type="button" onClick={() => removeRssSubscription(item.id)}>
+                    删除
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {loading ? <p className="muted">正在加载 RSS 资讯...</p> : null}
         {error ? <p className="muted">{error}</p> : null}
+
         <div style={{ display: 'grid', gap: 10 }}>
           {news.map((item) => (
-            <a
+            <button
               key={item.id}
-              href={item.link}
-              target="_blank"
-              rel="noreferrer"
+              type="button"
               className="card"
-              style={{ padding: 12, textDecoration: 'none', color: 'inherit' }}
+              onClick={() => setActiveNewsId(item.id)}
+              style={{
+                padding: 12,
+                textAlign: 'left',
+                border:
+                  activeNews?.id === item.id
+                    ? '1px solid var(--color-primary, #2563eb)'
+                    : '1px solid var(--color-border)',
+                background: 'transparent'
+              }}
             >
               <strong>{item.title}</strong>
               <p className="muted" style={{ marginBottom: 0 }}>
                 {item.source} · {item.publishedAt}
               </p>
-            </a>
+            </button>
           ))}
         </div>
       </section>
+
+      {activeNews ? (
+        <section className="card">
+          <h3 style={{ marginTop: 0 }}>🧾 RSS 阅读器</h3>
+          <h4>{activeNews.title}</h4>
+          <p className="muted" style={{ marginTop: 0 }}>
+            {activeNews.source} · {activeNews.publishedAt}
+          </p>
+          <p>{activeNews.summary || '该订阅源未提供摘要，请点击下方链接阅读原文。'}</p>
+          <a href={activeNews.link} target="_blank" rel="noreferrer">
+            打开原文
+          </a>
+        </section>
+      ) : null}
 
       <section className="card">
         <h3 style={{ marginTop: 0 }}>💡 今日金融小建议</h3>

--- a/src/shared/store/useAppPreferences.test.ts
+++ b/src/shared/store/useAppPreferences.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAppPreferences } from './useAppPreferences';
+
+describe('useAppPreferences RSS subscriptions', () => {
+  beforeEach(() => {
+    localStorage.removeItem('ledgerflow-preferences');
+    useAppPreferences.setState({
+      theme: 'system',
+      syncTargetDb: 'postgresql',
+      rssSubscriptions: [
+        {
+          id: 'rss-financial-times-markets',
+          title: 'Financial Times · Markets',
+          url: 'https://www.ft.com/markets?format=rss',
+          enabled: true
+        },
+        {
+          id: 'rss-yahoo-finance-top',
+          title: 'Yahoo Finance · Top News',
+          url: 'https://finance.yahoo.com/news/rssindex',
+          enabled: true
+        }
+      ]
+    });
+  });
+
+  it('should add a valid RSS feed and reject duplicates', () => {
+    const first = useAppPreferences.getState().addRssSubscription({
+      title: 'Reuters Markets',
+      url: 'https://www.reutersagency.com/feed/?best-topics=business-finance'
+    });
+    const second = useAppPreferences.getState().addRssSubscription({
+      title: 'Reuters Markets 2',
+      url: 'https://www.reutersagency.com/feed/?best-topics=business-finance'
+    });
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(false);
+    expect(second.reason).toContain('已订阅');
+  });
+
+  it('should toggle and remove RSS subscription', () => {
+    const current = useAppPreferences.getState().rssSubscriptions[0];
+    useAppPreferences.getState().toggleRssSubscription(current.id);
+    const toggled = useAppPreferences
+      .getState()
+      .rssSubscriptions.find((item) => item.id === current.id);
+
+    expect(toggled?.enabled).toBe(false);
+
+    useAppPreferences.getState().removeRssSubscription(current.id);
+    const removed = useAppPreferences
+      .getState()
+      .rssSubscriptions.find((item) => item.id === current.id);
+
+    expect(removed).toBeUndefined();
+  });
+});

--- a/src/shared/store/useAppPreferences.ts
+++ b/src/shared/store/useAppPreferences.ts
@@ -4,11 +4,50 @@ import { AppTheme } from '../types/app';
 
 export type SyncTargetDbPreference = 'postgresql' | 'mysql';
 
+export type RssSubscription = {
+  id: string;
+  title: string;
+  url: string;
+  enabled: boolean;
+};
+
+const DEFAULT_RSS_SUBSCRIPTIONS: RssSubscription[] = [
+  {
+    id: 'rss-financial-times-markets',
+    title: 'Financial Times · Markets',
+    url: 'https://www.ft.com/markets?format=rss',
+    enabled: true
+  },
+  {
+    id: 'rss-yahoo-finance-top',
+    title: 'Yahoo Finance · Top News',
+    url: 'https://finance.yahoo.com/news/rssindex',
+    enabled: true
+  }
+];
+
 interface AppPreferencesState {
   theme: AppTheme;
   syncTargetDb: SyncTargetDbPreference;
+  rssSubscriptions: RssSubscription[];
   setTheme: (theme: AppTheme) => void;
   setSyncTargetDb: (target: SyncTargetDbPreference) => void;
+  addRssSubscription: (payload: { title: string; url: string }) => { ok: boolean; reason?: string };
+  removeRssSubscription: (id: string) => void;
+  toggleRssSubscription: (id: string) => void;
+}
+
+function normalizeFeedUrl(rawUrl: string): string {
+  return String(rawUrl || '').trim();
+}
+
+function createSubscriptionId(url: string): string {
+  const normalized = normalizeFeedUrl(url)
+    .toLocaleLowerCase('en-US')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+  return `rss-${normalized || 'custom'}-${Date.now()}`;
 }
 
 export const useAppPreferences = create<AppPreferencesState>()(
@@ -16,8 +55,56 @@ export const useAppPreferences = create<AppPreferencesState>()(
     (set) => ({
       theme: 'system',
       syncTargetDb: 'postgresql',
+      rssSubscriptions: DEFAULT_RSS_SUBSCRIPTIONS,
       setTheme: (theme) => set({ theme }),
-      setSyncTargetDb: (target) => set({ syncTargetDb: target })
+      setSyncTargetDb: (target) => set({ syncTargetDb: target }),
+      addRssSubscription: ({ title, url }) => {
+        const normalizedUrl = normalizeFeedUrl(url);
+        if (!normalizedUrl) return { ok: false, reason: '请输入 RSS 地址。' };
+
+        let parsed: URL;
+        try {
+          parsed = new URL(normalizedUrl);
+        } catch {
+          return { ok: false, reason: 'RSS 地址格式无效。' };
+        }
+
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          return { ok: false, reason: '仅支持 http/https 的 RSS 地址。' };
+        }
+
+        let isDuplicate = false;
+        set((state) => {
+          isDuplicate = state.rssSubscriptions.some(
+            (item) =>
+              item.url.toLocaleLowerCase('en-US') === normalizedUrl.toLocaleLowerCase('en-US')
+          );
+          if (isDuplicate) return state;
+
+          const next = {
+            id: createSubscriptionId(normalizedUrl),
+            title: title.trim() || parsed.hostname,
+            url: normalizedUrl,
+            enabled: true
+          };
+          return { rssSubscriptions: [next, ...state.rssSubscriptions] };
+        });
+
+        if (isDuplicate) return { ok: false, reason: '该 RSS 已订阅。' };
+        return { ok: true };
+      },
+      removeRssSubscription: (id) => {
+        set((state) => ({
+          rssSubscriptions: state.rssSubscriptions.filter((item) => item.id !== id)
+        }));
+      },
+      toggleRssSubscription: (id) => {
+        set((state) => ({
+          rssSubscriptions: state.rssSubscriptions.map((item) =>
+            item.id === id ? { ...item, enabled: !item.enabled } : item
+          )
+        }));
+      }
     }),
     { name: 'ledgerflow-preferences' }
   )


### PR DESCRIPTION
### Motivation

- 目前金融资讯页面依赖单一远端接口，无法让用户订阅自选信息源或在应用内阅读 RSS/Atom 内容。  
- 目标是为金融资讯增加可配置的 RSS 订阅管理与内置阅读器，使资讯来源可定制并能在网络异常时回退到内置内容。

### Description

- 在偏好 store 中新增 RSS 支持：添加 `RssSubscription` 类型、`DEFAULT_RSS_SUBSCRIPTIONS`、并实现 `addRssSubscription`、`removeRssSubscription`、`toggleRssSubscription`（含 URL 校验与重复检测），数据持久化到 `ledgerflow-preferences`（文件: `src/shared/store/useAppPreferences.ts`）。
- 重构金融页面以支持多订阅源拉取与解析：新增 RSS/Atom XML 解析器、通过 `allorigins` 做跨域拉取、合并并排序多源条目、失败时回退到内置资讯（文件: `src/pages/finance/FinancePage.tsx`）。
- 在 UI 上新增“RSS 订阅管理”与“RSS 阅读器”区域：允许新增订阅（名称+URL）、启用/停用、删除，并在页面展示订阅条目与摘要，点击可在内置阅读区查看并跳转原文。
- 新增单元测试覆盖偏好 store 的 RSS 行为（新增、去重、启停、删除）：`src/shared/store/useAppPreferences.test.ts`。

### Testing

- 运行 `npm test -- src/shared/store/useAppPreferences.test.ts`，单测通过（2 个测试通过）。
- 运行 `npm run lint`，ESLint 检查通过（无错误）。
- 运行 `npm run build`，构建成功（Vite 构建通过）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991295db6048331a7d944c28c777a26)