### PR TITLE
feat: add smart budget wizard with category recommendations

### DIFF
--- a/src/app/router/router.tsx
+++ b/src/app/router/router.tsx
@@ -10,6 +10,7 @@ import { AssistantPage } from '../../pages/assistant/AssistantPage';
 import { DatabaseSettingsPage } from '../../pages/database-settings/DatabaseSettingsPage';
 import { ExchangePage } from '../../features/exchange/ui/ExchangePage';
 import { FinancePage } from '../../pages/finance/FinancePage';
+import { SmartBudgetPage } from '../../pages/smart-budget/SmartBudgetPage';
 
 export const router = createBrowserRouter([
   {
@@ -27,6 +28,7 @@ export const router = createBrowserRouter([
       { path: 'database-settings', element: <DatabaseSettingsPage /> },
       { path: 'exchange', element: <ExchangePage /> },
       { path: 'finance', element: <FinancePage /> },
+      { path: 'smart-budget', element: <SmartBudgetPage /> },
       { path: 'tags', element: <Navigate to="/categories-accounts" replace /> }
     ]
   }

--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -5599,3 +5599,160 @@ small.mono {
     font-size: 16px;
   }
 }
+
+/* ============================================================
+   Smart Budget
+   ============================================================ */
+.smart-budget-page {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.smart-budget-header p {
+  margin: var(--space-2) 0 0;
+}
+
+.smart-budget-stepper {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.smart-budget-stepper span {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 6px 8px;
+  font-size: var(--font-xs);
+  color: var(--color-text-secondary);
+  text-align: center;
+  background: var(--color-bg-subtle);
+}
+
+.smart-budget-stepper span.active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: var(--color-primary-bg);
+  font-weight: 600;
+}
+
+.smart-budget-stepper span.done {
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border));
+}
+
+.smart-budget-block {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  background: var(--color-bg-subtle);
+}
+
+.smart-budget-block h3 {
+  margin-bottom: var(--space-2);
+}
+
+.smart-budget-block p {
+  margin: 0 0 var(--space-3);
+}
+
+.smart-budget-choice-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-3);
+}
+
+.smart-budget-choice-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: var(--color-bg-elevated);
+  display: grid;
+  gap: var(--space-1);
+  cursor: pointer;
+}
+
+.smart-budget-choice-card input {
+  justify-self: start;
+  margin: 0;
+}
+
+.smart-budget-choice-card strong {
+  font-size: var(--font-base);
+}
+
+.smart-budget-choice-card span {
+  font-size: var(--font-xs);
+  color: var(--color-text-secondary);
+}
+
+.smart-budget-ratio-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.smart-budget-ratio-options button.active {
+  color: #fff;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.smart-budget-result-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.smart-budget-stat-card {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  padding: var(--space-3);
+  display: grid;
+  gap: 2px;
+}
+
+.smart-budget-stat-card span {
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+}
+
+.smart-budget-stat-card strong {
+  font-size: var(--font-md);
+}
+
+.smart-budget-table {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.smart-budget-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.smart-budget-footer {
+  display: flex;
+  justify-content: space-between;
+}
+
+.smart-budget-error {
+  margin: 0;
+  color: var(--color-danger);
+  font-size: var(--font-sm);
+}
+
+.smart-budget-confirmed {
+  margin-bottom: 0;
+}
+
+@media (max-width: 680px) {
+  .smart-budget-stepper {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/features/smart-budget/model/budgetPlanner.test.ts
+++ b/src/features/smart-budget/model/budgetPlanner.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { generateBudgetRecommendation } from './budgetPlanner';
+
+describe('generateBudgetRecommendation', () => {
+  it('should keep total category budgets equal to monthly income', () => {
+    const result = generateBudgetRecommendation({
+      identity: 'employee',
+      monthlyIncomeK: 12,
+      monthlyFixedExpenseK: 4,
+      savingsRatio: 0.35
+    });
+
+    const total = result.categoryBudgets.reduce((sum, item) => sum + item.amount, 0);
+    expect(total).toBe(result.monthlyIncome);
+    expect(result.flexibleBudget).toBeGreaterThan(0);
+  });
+
+  it('should throw when income is zero', () => {
+    expect(() =>
+      generateBudgetRecommendation({
+        identity: 'student',
+        monthlyIncomeK: 0,
+        monthlyFixedExpenseK: 1,
+        savingsRatio: 0.2
+      })
+    ).toThrow('每月收入必须大于 0。');
+  });
+
+  it('should throw when fixed expense is not lower than income', () => {
+    expect(() =>
+      generateBudgetRecommendation({
+        identity: 'freelancer',
+        monthlyIncomeK: 6,
+        monthlyFixedExpenseK: 6,
+        savingsRatio: 0.3
+      })
+    ).toThrow('固定支出需要小于月收入，才能生成可执行预算。');
+  });
+});

--- a/src/features/smart-budget/model/budgetPlanner.ts
+++ b/src/features/smart-budget/model/budgetPlanner.ts
@@ -1,0 +1,164 @@
+export type UserIdentity = 'student' | 'employee' | 'freelancer' | 'other';
+
+export type BudgetAnswers = {
+  identity: UserIdentity;
+  monthlyIncomeK: number;
+  monthlyFixedExpenseK: number;
+  savingsRatio: number;
+};
+
+export type BudgetCategoryPlan = {
+  category: string;
+  amount: number;
+  ratio: number;
+};
+
+export type BudgetRecommendation = {
+  monthlyIncome: number;
+  monthlyFixedExpense: number;
+  disposableIncome: number;
+  savingsAmount: number;
+  flexibleBudget: number;
+  categoryBudgets: BudgetCategoryPlan[];
+};
+
+const IDENTITY_LABELS: Record<UserIdentity, string> = {
+  student: '学生',
+  employee: '上班族',
+  freelancer: '自由职业者',
+  other: '其他'
+};
+
+const FLEXIBLE_CATEGORY_WEIGHT: Record<
+  UserIdentity,
+  Array<{ category: string; weight: number }>
+> = {
+  student: [
+    { category: '餐饮', weight: 0.3 },
+    { category: '学习成长', weight: 0.28 },
+    { category: '交通', weight: 0.12 },
+    { category: '娱乐社交', weight: 0.18 },
+    { category: '医疗健康', weight: 0.12 }
+  ],
+  employee: [
+    { category: '餐饮', weight: 0.26 },
+    { category: '交通', weight: 0.16 },
+    { category: '通讯网络', weight: 0.12 },
+    { category: '家庭生活', weight: 0.24 },
+    { category: '娱乐社交', weight: 0.12 },
+    { category: '学习成长', weight: 0.1 }
+  ],
+  freelancer: [
+    { category: '餐饮', weight: 0.22 },
+    { category: '交通', weight: 0.12 },
+    { category: '工作投入', weight: 0.26 },
+    { category: '家庭生活', weight: 0.18 },
+    { category: '医疗健康', weight: 0.1 },
+    { category: '娱乐社交', weight: 0.12 }
+  ],
+  other: [
+    { category: '餐饮', weight: 0.24 },
+    { category: '交通', weight: 0.14 },
+    { category: '家庭生活', weight: 0.24 },
+    { category: '医疗健康', weight: 0.14 },
+    { category: '学习成长', weight: 0.12 },
+    { category: '娱乐社交', weight: 0.12 }
+  ]
+};
+
+function toAmountFromK(value: number): number {
+  return Math.round(value * 1000);
+}
+
+function roundToTen(amount: number): number {
+  return Math.round(amount / 10) * 10;
+}
+
+function normalizeWeights(
+  items: Array<{ category: string; weight: number }>
+): Array<{ category: string; weight: number }> {
+  const totalWeight = items.reduce((sum, item) => sum + item.weight, 0);
+  if (totalWeight <= 0) {
+    return items.map((item) => ({ ...item, weight: 1 / items.length }));
+  }
+  return items.map((item) => ({ ...item, weight: item.weight / totalWeight }));
+}
+
+/**
+ * 根据四个问答结果生成预算建议。
+ * - 问题 2/3 使用“千”为单位输入，函数内部统一转为元。
+ * - 预算会拆分为固定支出、储蓄与灵活支出分类，且总额严格等于月收入。
+ */
+export function generateBudgetRecommendation(answers: BudgetAnswers): BudgetRecommendation {
+  if (!Number.isFinite(answers.monthlyIncomeK) || answers.monthlyIncomeK <= 0) {
+    throw new Error('每月收入必须大于 0。');
+  }
+  if (!Number.isFinite(answers.monthlyFixedExpenseK) || answers.monthlyFixedExpenseK < 0) {
+    throw new Error('固定支出不能小于 0。');
+  }
+  if (
+    !Number.isFinite(answers.savingsRatio) ||
+    answers.savingsRatio < 0.1 ||
+    answers.savingsRatio > 0.6
+  ) {
+    throw new Error('预算比例应在 10%~60% 之间。');
+  }
+
+  const monthlyIncome = toAmountFromK(answers.monthlyIncomeK);
+  const monthlyFixedExpense = toAmountFromK(answers.monthlyFixedExpenseK);
+
+  if (monthlyFixedExpense >= monthlyIncome) {
+    throw new Error('固定支出需要小于月收入，才能生成可执行预算。');
+  }
+
+  const disposableIncome = monthlyIncome - monthlyFixedExpense;
+  const savingsAmount = roundToTen(disposableIncome * answers.savingsRatio);
+  const flexibleBudget = monthlyIncome - monthlyFixedExpense - savingsAmount;
+
+  const dynamicWeights = normalizeWeights(FLEXIBLE_CATEGORY_WEIGHT[answers.identity]);
+
+  const dynamicPlans: BudgetCategoryPlan[] = dynamicWeights.map((item) => ({
+    category: item.category,
+    amount: roundToTen(flexibleBudget * item.weight),
+    ratio: 0
+  }));
+
+  const dynamicBudgetUsed = dynamicPlans.reduce((sum, item) => sum + item.amount, 0);
+  const dynamicDelta = flexibleBudget - dynamicBudgetUsed;
+  if (dynamicPlans.length > 0 && dynamicDelta !== 0) {
+    dynamicPlans[0] = {
+      ...dynamicPlans[0],
+      amount: dynamicPlans[0].amount + dynamicDelta
+    };
+  }
+
+  const categoryBudgets = [
+    {
+      category: '固定支出',
+      amount: monthlyFixedExpense,
+      ratio: 0
+    },
+    {
+      category: '储蓄/投资',
+      amount: savingsAmount,
+      ratio: 0
+    },
+    ...dynamicPlans
+  ].map((item) => ({
+    ...item,
+    ratio: monthlyIncome > 0 ? item.amount / monthlyIncome : 0
+  }));
+
+  return {
+    monthlyIncome,
+    monthlyFixedExpense,
+    disposableIncome,
+    savingsAmount,
+    flexibleBudget,
+    categoryBudgets
+  };
+}
+
+export function getIdentityLabel(identity: UserIdentity): string {
+  return IDENTITY_LABELS[identity];
+}

--- a/src/pages/smart-budget/SmartBudgetPage.tsx
+++ b/src/pages/smart-budget/SmartBudgetPage.tsx
@@ -1,0 +1,297 @@
+import { useMemo, useState } from 'react';
+import { formatCurrency } from '../../shared/lib/format';
+import {
+  BudgetAnswers,
+  BudgetRecommendation,
+  UserIdentity,
+  generateBudgetRecommendation,
+  getIdentityLabel
+} from '../../features/smart-budget/model/budgetPlanner';
+import { useSmartBudgetStore } from '../../shared/store/useSmartBudgetStore';
+
+const identityOptions: Array<{ value: UserIdentity; label: string; helper: string }> = [
+  { value: 'student', label: '学生', helper: '课程、成长和生活费通常占比较高。' },
+  { value: 'employee', label: '上班族', helper: '通勤、家庭与长期储蓄需要更平衡。' },
+  { value: 'freelancer', label: '自由职业者', helper: '收入波动较大，建议提高风险缓冲。' },
+  { value: 'other', label: '其他', helper: '系统会按通用支出结构推荐。' }
+];
+
+const ratioQuickOptions = [0.2, 0.3, 0.4, 0.5];
+
+const initialAnswers: BudgetAnswers = {
+  identity: 'employee',
+  monthlyIncomeK: 10,
+  monthlyFixedExpenseK: 3,
+  savingsRatio: 0.3
+};
+
+export function SmartBudgetPage() {
+  const [step, setStep] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+  const [answers, setAnswers] = useState<BudgetAnswers>(initialAnswers);
+  const [draftRecommendation, setDraftRecommendation] = useState<BudgetRecommendation | null>(null);
+  const confirmedPlan = useSmartBudgetStore((s) => s.confirmedPlan);
+  const confirmPlan = useSmartBudgetStore((s) => s.confirmPlan);
+  const clearPlan = useSmartBudgetStore((s) => s.clearPlan);
+
+  const summary = useMemo(
+    () =>
+      `身份：${getIdentityLabel(answers.identity)} · 月收入：${answers.monthlyIncomeK} 千 · 固定支出：${answers.monthlyFixedExpenseK} 千 · 储蓄比例：${Math.round(answers.savingsRatio * 100)}%`,
+    [answers]
+  );
+
+  const goNext = () => {
+    setError(null);
+
+    if (step === 2 && answers.monthlyIncomeK <= 0) {
+      setError('每月收入必须大于 0。');
+      return;
+    }
+
+    if (step === 3) {
+      if (answers.monthlyFixedExpenseK < 0) {
+        setError('固定支出不能为负数。');
+        return;
+      }
+      if (answers.monthlyFixedExpenseK >= answers.monthlyIncomeK) {
+        setError('固定支出必须小于每月收入。');
+        return;
+      }
+    }
+
+    if (step === 4) {
+      try {
+        const result = generateBudgetRecommendation(answers);
+        setDraftRecommendation(result);
+      } catch (validationError) {
+        setError(validationError instanceof Error ? validationError.message : '预算生成失败。');
+        return;
+      }
+    }
+
+    setStep((current) => Math.min(current + 1, 5));
+  };
+
+  const goPrev = () => {
+    setError(null);
+    setStep((current) => Math.max(current - 1, 1));
+  };
+
+  const handleConfirm = () => {
+    if (!draftRecommendation) {
+      return;
+    }
+    confirmPlan({ answers, recommendation: draftRecommendation });
+  };
+
+  return (
+    <section className="panel smart-budget-page">
+      <header className="smart-budget-header">
+        <h2>智能预算</h2>
+        <p>通过 4 个问题快速生成可执行的月度分类预算，并支持一键确认保存。</p>
+      </header>
+
+      <div className="smart-budget-stepper" aria-label="预算问答步骤">
+        {[1, 2, 3, 4, 5].map((value) => (
+          <span
+            key={value}
+            className={value === step ? 'active' : value < step ? 'done' : ''}
+            aria-current={value === step ? 'step' : undefined}
+          >
+            {value <= 4 ? `问题 ${value}` : '确认'}
+          </span>
+        ))}
+      </div>
+
+      {step === 1 ? (
+        <div className="smart-budget-block">
+          <h3>问题 1：你目前的身份是？</h3>
+          <div className="smart-budget-choice-grid">
+            {identityOptions.map((item) => (
+              <label key={item.value} className="smart-budget-choice-card">
+                <input
+                  type="radio"
+                  name="identity"
+                  value={item.value}
+                  checked={answers.identity === item.value}
+                  onChange={() => setAnswers((prev) => ({ ...prev, identity: item.value }))}
+                />
+                <strong>{item.label}</strong>
+                <span>{item.helper}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {step === 2 ? (
+        <div className="smart-budget-block">
+          <h3>问题 2：每月收入（禁止输入 0，以千为单位）</h3>
+          <div className="field">
+            <label htmlFor="income-k">示例：8 代表 8000 元</label>
+            <input
+              id="income-k"
+              type="number"
+              min={1}
+              step={1}
+              value={answers.monthlyIncomeK}
+              onChange={(event) =>
+                setAnswers((prev) => ({ ...prev, monthlyIncomeK: Number(event.target.value) }))
+              }
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {step === 3 ? (
+        <div className="smart-budget-block">
+          <h3>问题 3：每月固定支出有多少（以千为单位）</h3>
+          <p>包含房租/房贷、固定账单、长期订阅等刚性成本。</p>
+          <div className="field">
+            <label htmlFor="fixed-expense-k">示例：3 代表 3000 元</label>
+            <input
+              id="fixed-expense-k"
+              type="number"
+              min={0}
+              step={0.5}
+              value={answers.monthlyFixedExpenseK}
+              onChange={(event) =>
+                setAnswers((prev) => ({
+                  ...prev,
+                  monthlyFixedExpenseK: Number(event.target.value)
+                }))
+              }
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {step === 4 ? (
+        <div className="smart-budget-block">
+          <h3>问题 4：设置预算比例（快捷选择或滑动选择）</h3>
+          <p>该比例用于“可支配收入”中的储蓄/投资占比。</p>
+
+          <div className="smart-budget-ratio-options">
+            {ratioQuickOptions.map((ratio) => (
+              <button
+                key={ratio}
+                type="button"
+                className={answers.savingsRatio === ratio ? 'active' : ''}
+                onClick={() => setAnswers((prev) => ({ ...prev, savingsRatio: ratio }))}
+              >
+                {Math.round(ratio * 100)}%
+              </button>
+            ))}
+          </div>
+
+          <div className="field">
+            <label htmlFor="savings-ratio-range">
+              当前比例：{Math.round(answers.savingsRatio * 100)}%
+            </label>
+            <input
+              id="savings-ratio-range"
+              type="range"
+              min={10}
+              max={60}
+              step={1}
+              value={Math.round(answers.savingsRatio * 100)}
+              onChange={(event) =>
+                setAnswers((prev) => ({ ...prev, savingsRatio: Number(event.target.value) / 100 }))
+              }
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {step === 5 && draftRecommendation ? (
+        <div className="smart-budget-block">
+          <h3>月分类预算推荐（可确认保存）</h3>
+          <p>{summary}</p>
+          <div className="smart-budget-result-grid">
+            <article className="smart-budget-stat-card">
+              <span>月收入</span>
+              <strong>{formatCurrency(draftRecommendation.monthlyIncome)}</strong>
+            </article>
+            <article className="smart-budget-stat-card">
+              <span>固定支出</span>
+              <strong>{formatCurrency(draftRecommendation.monthlyFixedExpense)}</strong>
+            </article>
+            <article className="smart-budget-stat-card">
+              <span>储蓄/投资</span>
+              <strong>{formatCurrency(draftRecommendation.savingsAmount)}</strong>
+            </article>
+            <article className="smart-budget-stat-card">
+              <span>灵活预算</span>
+              <strong>{formatCurrency(draftRecommendation.flexibleBudget)}</strong>
+            </article>
+          </div>
+
+          <div className="table-wrap">
+            <table className="table smart-budget-table">
+              <thead>
+                <tr>
+                  <th>分类</th>
+                  <th>金额</th>
+                  <th>占月收入比例</th>
+                </tr>
+              </thead>
+              <tbody>
+                {draftRecommendation.categoryBudgets.map((row) => (
+                  <tr key={row.category}>
+                    <td>{row.category}</td>
+                    <td>{formatCurrency(row.amount)}</td>
+                    <td>{(row.ratio * 100).toFixed(1)}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="smart-budget-actions">
+            <button type="button" className="primary" onClick={handleConfirm}>
+              确认使用该预算建议
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setDraftRecommendation(null);
+                setStep(1);
+                setError(null);
+              }}
+            >
+              重新填写问答
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {error ? <p className="smart-budget-error">{error}</p> : null}
+
+      <footer className="smart-budget-footer">
+        <button type="button" onClick={goPrev} disabled={step === 1}>
+          上一步
+        </button>
+        <button type="button" className="primary" onClick={goNext} disabled={step >= 5}>
+          {step === 4 ? '生成预算推荐' : '下一步'}
+        </button>
+      </footer>
+
+      {confirmedPlan ? (
+        <section className="smart-budget-confirmed panel">
+          <h3>已确认预算</h3>
+          <p>
+            最近确认时间：
+            {new Date(confirmedPlan.confirmedAt).toLocaleString('zh-CN', { hour12: false })}
+          </p>
+          <p>
+            身份：{getIdentityLabel(confirmedPlan.answers.identity)}，储蓄比例：
+            {Math.round(confirmedPlan.answers.savingsRatio * 100)}%
+          </p>
+          <button type="button" onClick={clearPlan}>
+            清除已确认预算
+          </button>
+        </section>
+      ) : null}
+    </section>
+  );
+}

--- a/src/shared/store/useSmartBudgetStore.ts
+++ b/src/shared/store/useSmartBudgetStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import {
+  BudgetAnswers,
+  BudgetRecommendation
+} from '../../features/smart-budget/model/budgetPlanner';
+
+export type ConfirmedSmartBudgetPlan = {
+  answers: BudgetAnswers;
+  recommendation: BudgetRecommendation;
+  confirmedAt: string;
+};
+
+interface SmartBudgetState {
+  confirmedPlan: ConfirmedSmartBudgetPlan | null;
+  confirmPlan: (payload: { answers: BudgetAnswers; recommendation: BudgetRecommendation }) => void;
+  clearPlan: () => void;
+}
+
+/**
+ * 智能预算确认结果存储。
+ * 仅保存用户最终确认的建议，避免中间步骤污染全局状态。
+ */
+export const useSmartBudgetStore = create<SmartBudgetState>()(
+  persist(
+    (set) => ({
+      confirmedPlan: null,
+      confirmPlan: ({ answers, recommendation }) => {
+        set({
+          confirmedPlan: {
+            answers,
+            recommendation,
+            confirmedAt: new Date().toISOString()
+          }
+        });
+      },
+      clearPlan: () => set({ confirmedPlan: null })
+    }),
+    { name: 'ledgerflow-smart-budget' }
+  )
+);

--- a/src/widgets/layout/AppLayout.tsx
+++ b/src/widgets/layout/AppLayout.tsx
@@ -25,7 +25,10 @@ type QuickEntry = {
 const navSections: Array<{ title: string; items: NavItem[] }> = [
   {
     title: 'AI 助手',
-    items: [{ to: '/assistant', label: '记账助手', icon: '🤖' }]
+    items: [
+      { to: '/assistant', label: '记账助手', icon: '🤖' },
+      { to: '/smart-budget', label: '智能预算', icon: '🧠' }
+    ]
   },
   {
     title: '交易数据',
@@ -62,6 +65,7 @@ const mobileQuickGroups: Array<{ title: string; items: QuickEntry[] }> = [
     title: '高频入口',
     items: [
       { label: '记账助手', icon: '🤖', to: '/assistant' },
+      { label: '智能预算', icon: '🧠', to: '/smart-budget' },
       { label: '交易详情', icon: '📋', to: '/transactions' },
       { label: '统计分析', icon: '📊', to: '/', end: true },
       { label: '分类账户', icon: '🗂️', to: '/categories-accounts' },


### PR DESCRIPTION
### Motivation

- 为侧边栏新增“智能预算”功能页，提供基于简短问答（身份/月收入/固定支出/储蓄比例）的快速预算生成能力，帮助用户快速得到可执行的月度分类预算建议。
- 需要在前端保证输入校验与预算总额一致性，并允许用户确认后持久化已确认方案以免污染全局草稿状态。

### Description

- 新增预算模型和推荐引擎 `src/features/smart-budget/model/budgetPlanner.ts`，实现收入/固定支出/储蓄比例校验、分类权重分配、舍入并回补保证总额等逻辑，并附带中文注释说明计算规则。
- 添加 Smart Budget 页面 `src/pages/smart-budget/SmartBudgetPage.tsx`，实现 4 问答 + 确认流程、即时校验、错误提示、重填与确认保存交互，并在 UI 中展示分类预算表格。
- 新增持久化 store `src/shared/store/useSmartBudgetStore.ts`，仅保存用户“已确认”的预算方案（含确认时间）。
- 将功能入口接入应用：在侧边栏与移动抽屉增加“智能预算”菜单项并注册路由 `'/smart-budget'`（修改了 `src/widgets/layout/AppLayout.tsx`、`src/app/router/router.tsx`）。
- 增加页面样式到全局样式 `src/app/styles/global.css` 并新增单元测试 `src/features/smart-budget/model/budgetPlanner.test.ts` 验证推荐引擎的重要行为。

### Testing

- 运行单元测试 `vitest` 针对 `src/features/smart-budget/model/budgetPlanner.test.ts`，3 个测试用例全部通过（通过）。
- 运行静态检查 `eslint`，代码检查/自动修复通过（通过）。
- 生产构建 `vite build` 完成，构建成功（通过）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69912b867aec83318072769fbaf90ca4)