### PR TITLE
feat: add smart budget management dashboard with overspend tracking

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -5612,6 +5612,108 @@ small.mono {
   margin: var(--space-2) 0 0;
 }
 
+.smart-budget-mode-switch {
+  display: inline-flex;
+  gap: var(--space-2);
+  padding: 4px;
+  border-radius: var(--radius-md);
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border-light);
+}
+
+.smart-budget-mode-switch button.active {
+  color: #fff;
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+}
+
+.smart-budget-management {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: grid;
+  gap: var(--space-3);
+  background: var(--color-bg-subtle);
+}
+
+.smart-budget-management-topbar {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.smart-budget-filter-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.smart-budget-filter-group button.active {
+  color: #fff;
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+}
+
+.smart-budget-progress-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-3);
+}
+
+.smart-budget-progress-card {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: var(--color-bg-elevated);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.smart-budget-progress-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.smart-budget-progress-card h4,
+.smart-budget-progress-card p {
+  margin: 0;
+}
+
+.smart-budget-progress-card .warn {
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.smart-budget-progress-card .safe {
+  color: var(--color-success);
+  font-weight: 600;
+}
+
+.smart-budget-progress-track {
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--color-border-light);
+  overflow: hidden;
+}
+
+.smart-budget-progress-track span {
+  display: block;
+  height: 100%;
+  background: var(--color-success);
+}
+
+.smart-budget-progress-track span.warn {
+  background: var(--color-danger);
+}
+
+.smart-budget-empty {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
 .smart-budget-stepper {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));

--- a/src/features/smart-budget/model/budgetInsights.test.ts
+++ b/src/features/smart-budget/model/budgetInsights.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { buildBudgetTrackingRows, formatMonthKey, getRecentMonthOptions } from './budgetInsights';
+import { BudgetRecommendation } from './budgetPlanner';
+
+const recommendation: BudgetRecommendation = {
+  monthlyIncome: 10000,
+  monthlyFixedExpense: 3000,
+  disposableIncome: 7000,
+  savingsAmount: 2000,
+  flexibleBudget: 5000,
+  categoryBudgets: [
+    { category: '固定支出', amount: 3000, ratio: 0.3 },
+    { category: '储蓄/投资', amount: 2000, ratio: 0.2 },
+    { category: '餐饮', amount: 2000, ratio: 0.2 },
+    { category: '交通', amount: 1200, ratio: 0.12 },
+    { category: '娱乐社交', amount: 1800, ratio: 0.18 }
+  ]
+};
+
+describe('budgetInsights', () => {
+  it('returns recent month options sorted by desc', () => {
+    const options = getRecentMonthOptions(
+      [
+        {
+          id: '1',
+          type: 'expense',
+          categoryId: 'food',
+          accountId: 'cash',
+          amount: 100,
+          date: '2025-01-02',
+          note: '',
+          tags: []
+        }
+      ],
+      3,
+      new Date('2025-02-15')
+    );
+
+    expect(options.map((item) => item.key)).toEqual(['2025-02', '2025-01', '2024-12']);
+  });
+
+  it('builds tracking rows and marks overspent categories', () => {
+    const monthKey = formatMonthKey(new Date('2025-02-08'));
+    const rows = buildBudgetTrackingRows({
+      recommendation,
+      categories: [
+        { id: 'food', name: '餐饮' },
+        { id: 'traffic', name: '交通' },
+        { id: 'fun', name: '娱乐社交' }
+      ],
+      transactions: [
+        {
+          id: '1',
+          type: 'expense',
+          categoryId: 'food',
+          accountId: 'cash',
+          amount: 2100,
+          date: '2025-02-01',
+          note: '',
+          tags: []
+        },
+        {
+          id: '2',
+          type: 'expense',
+          categoryId: 'traffic',
+          accountId: 'cash',
+          amount: 300,
+          date: '2025-02-03',
+          note: '',
+          tags: []
+        }
+      ],
+      monthKey
+    });
+
+    expect(rows[0]).toMatchObject({
+      category: '餐饮',
+      budgetAmount: 2000,
+      spentAmount: 2100,
+      isOverspent: true
+    });
+    expect(rows.find((item) => item.category === '娱乐社交')).toMatchObject({
+      spentAmount: 0,
+      isOverspent: false
+    });
+  });
+});

--- a/src/features/smart-budget/model/budgetInsights.ts
+++ b/src/features/smart-budget/model/budgetInsights.ts
@@ -1,0 +1,109 @@
+import { BudgetRecommendation } from './budgetPlanner';
+import { Category } from '../../../entities/category/types';
+import { TransactionItem } from '../../../entities/transaction/types';
+
+export type BudgetMonthOption = {
+  key: string;
+  label: string;
+};
+
+export type BudgetTrackingRow = {
+  category: string;
+  budgetAmount: number;
+  spentAmount: number;
+  ratio: number;
+  diff: number;
+  isOverspent: boolean;
+};
+
+export function formatMonthKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+}
+
+function monthLabelFromKey(monthKey: string): string {
+  const [year, month] = monthKey.split('-');
+  return `${year} 年 ${Number(month)} 月`;
+}
+
+function normalizeCategoryName(raw: string): string {
+  return raw.trim().toLocaleLowerCase('zh-CN');
+}
+
+export function getRecentMonthOptions(
+  transactions: TransactionItem[],
+  count = 6,
+  now = new Date()
+): BudgetMonthOption[] {
+  const monthSet = new Set<string>();
+
+  transactions.forEach((item) => {
+    const date = new Date(item.date);
+    if (Number.isNaN(date.getTime())) {
+      return;
+    }
+    monthSet.add(formatMonthKey(date));
+  });
+
+  for (let offset = 0; offset < count; offset += 1) {
+    const current = new Date(now.getFullYear(), now.getMonth() - offset, 1);
+    monthSet.add(formatMonthKey(current));
+  }
+
+  return Array.from(monthSet)
+    .sort((a, b) => b.localeCompare(a))
+    .slice(0, count)
+    .map((key) => ({ key, label: monthLabelFromKey(key) }));
+}
+
+export function buildBudgetTrackingRows(params: {
+  recommendation: BudgetRecommendation;
+  transactions: TransactionItem[];
+  categories: Category[];
+  monthKey: string;
+}): BudgetTrackingRow[] {
+  const { recommendation, transactions, categories, monthKey } = params;
+  const categoryNameById = new Map(categories.map((item) => [item.id, item.name]));
+
+  const spentByCategory = new Map<string, number>();
+
+  transactions.forEach((item) => {
+    if (item.type !== 'expense') {
+      return;
+    }
+
+    const date = new Date(item.date);
+    if (Number.isNaN(date.getTime()) || formatMonthKey(date) !== monthKey) {
+      return;
+    }
+
+    const categoryName = categoryNameById.get(item.categoryId);
+    if (!categoryName) {
+      return;
+    }
+
+    const key = normalizeCategoryName(categoryName);
+    spentByCategory.set(key, (spentByCategory.get(key) || 0) + Number(item.amount || 0));
+  });
+
+  return recommendation.categoryBudgets
+    .filter((item) => !['固定支出', '储蓄/投资'].includes(item.category))
+    .map((item) => {
+      const key = normalizeCategoryName(item.category);
+      const spentAmount = Math.round((spentByCategory.get(key) || 0) * 100) / 100;
+      const budgetAmount = item.amount;
+      const diff = spentAmount - budgetAmount;
+      const ratio = budgetAmount > 0 ? spentAmount / budgetAmount : 0;
+
+      return {
+        category: item.category,
+        budgetAmount,
+        spentAmount,
+        ratio,
+        diff,
+        isOverspent: diff > 0
+      };
+    })
+    .sort((a, b) => b.ratio - a.ratio);
+}

--- a/src/pages/smart-budget/SmartBudgetPage.tsx
+++ b/src/pages/smart-budget/SmartBudgetPage.tsx
@@ -8,6 +8,11 @@ import {
   getIdentityLabel
 } from '../../features/smart-budget/model/budgetPlanner';
 import { useSmartBudgetStore } from '../../shared/store/useSmartBudgetStore';
+import { useFinanceStore } from '../../shared/store/useFinanceStore';
+import {
+  buildBudgetTrackingRows,
+  getRecentMonthOptions
+} from '../../features/smart-budget/model/budgetInsights';
 
 const identityOptions: Array<{ value: UserIdentity; label: string; helper: string }> = [
   { value: 'student', label: '学生', helper: '课程、成长和生活费通常占比较高。' },
@@ -26,13 +31,47 @@ const initialAnswers: BudgetAnswers = {
 };
 
 export function SmartBudgetPage() {
+  const [mode, setMode] = useState<'setup' | 'management'>('setup');
   const [step, setStep] = useState(1);
   const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<'all' | 'overspent' | 'safe'>('all');
   const [answers, setAnswers] = useState<BudgetAnswers>(initialAnswers);
   const [draftRecommendation, setDraftRecommendation] = useState<BudgetRecommendation | null>(null);
+  const [selectedMonthKey, setSelectedMonthKey] = useState('');
   const confirmedPlan = useSmartBudgetStore((s) => s.confirmedPlan);
   const confirmPlan = useSmartBudgetStore((s) => s.confirmPlan);
   const clearPlan = useSmartBudgetStore((s) => s.clearPlan);
+  const transactions = useFinanceStore((s) => s.transactions);
+  const categories = useFinanceStore((s) => s.categories);
+
+  const monthOptions = useMemo(() => getRecentMonthOptions(transactions), [transactions]);
+
+  const activeMonthKey = selectedMonthKey || monthOptions[0]?.key || '';
+
+  const trackingRows = useMemo(() => {
+    if (!confirmedPlan || !activeMonthKey) {
+      return [];
+    }
+
+    return buildBudgetTrackingRows({
+      recommendation: confirmedPlan.recommendation,
+      transactions,
+      categories,
+      monthKey: activeMonthKey
+    });
+  }, [confirmedPlan, transactions, categories, activeMonthKey]);
+
+  const visibleRows = useMemo(() => {
+    if (statusFilter === 'overspent') {
+      return trackingRows.filter((item) => item.isOverspent);
+    }
+    if (statusFilter === 'safe') {
+      return trackingRows.filter((item) => !item.isOverspent);
+    }
+    return trackingRows;
+  }, [statusFilter, trackingRows]);
+
+  const overspentCount = trackingRows.filter((item) => item.isOverspent).length;
 
   const summary = useMemo(
     () =>
@@ -82,215 +121,327 @@ export function SmartBudgetPage() {
       return;
     }
     confirmPlan({ answers, recommendation: draftRecommendation });
+    setMode('management');
+  };
+
+  const progressPercent = (ratio: number) => {
+    if (!Number.isFinite(ratio) || ratio <= 0) {
+      return 0;
+    }
+    return Math.min(Math.round(ratio * 100), 160);
   };
 
   return (
     <section className="panel smart-budget-page">
       <header className="smart-budget-header">
         <h2>智能预算</h2>
-        <p>通过 4 个问题快速生成可执行的月度分类预算，并支持一键确认保存。</p>
+        <p>通过 4 个问题快速生成预算，确认后进入预算管理查看近期预算执行是否超支。</p>
       </header>
 
-      <div className="smart-budget-stepper" aria-label="预算问答步骤">
-        {[1, 2, 3, 4, 5].map((value) => (
-          <span
-            key={value}
-            className={value === step ? 'active' : value < step ? 'done' : ''}
-            aria-current={value === step ? 'step' : undefined}
-          >
-            {value <= 4 ? `问题 ${value}` : '确认'}
-          </span>
-        ))}
+      <div className="smart-budget-mode-switch" role="tablist" aria-label="智能预算模式">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'setup'}
+          className={mode === 'setup' ? 'active' : ''}
+          onClick={() => setMode('setup')}
+        >
+          预算设置
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'management'}
+          className={mode === 'management' ? 'active' : ''}
+          onClick={() => setMode('management')}
+          disabled={!confirmedPlan}
+        >
+          智能预算管理
+        </button>
       </div>
 
-      {step === 1 ? (
-        <div className="smart-budget-block">
-          <h3>问题 1：你目前的身份是？</h3>
-          <div className="smart-budget-choice-grid">
-            {identityOptions.map((item) => (
-              <label key={item.value} className="smart-budget-choice-card">
-                <input
-                  type="radio"
-                  name="identity"
-                  value={item.value}
-                  checked={answers.identity === item.value}
-                  onChange={() => setAnswers((prev) => ({ ...prev, identity: item.value }))}
-                />
-                <strong>{item.label}</strong>
-                <span>{item.helper}</span>
-              </label>
-            ))}
-          </div>
-        </div>
-      ) : null}
+      {mode === 'management' ? (
+        confirmedPlan ? (
+          <section className="smart-budget-management" aria-label="智能预算管理看板">
+            <div className="smart-budget-management-topbar">
+              <div className="field">
+                <label htmlFor="budget-month">最近月份</label>
+                <select
+                  id="budget-month"
+                  value={activeMonthKey}
+                  onChange={(event) => setSelectedMonthKey(event.target.value)}
+                >
+                  {monthOptions.map((item) => (
+                    <option key={item.key} value={item.key}>
+                      {item.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="smart-budget-filter-group" role="group" aria-label="预算状态过滤">
+                <button
+                  type="button"
+                  className={statusFilter === 'all' ? 'active' : ''}
+                  onClick={() => setStatusFilter('all')}
+                >
+                  全部 {trackingRows.length}
+                </button>
+                <button
+                  type="button"
+                  className={statusFilter === 'overspent' ? 'active' : ''}
+                  onClick={() => setStatusFilter('overspent')}
+                >
+                  已超支 {overspentCount}
+                </button>
+                <button
+                  type="button"
+                  className={statusFilter === 'safe' ? 'active' : ''}
+                  onClick={() => setStatusFilter('safe')}
+                >
+                  正常 {trackingRows.length - overspentCount}
+                </button>
+              </div>
+            </div>
 
-      {step === 2 ? (
-        <div className="smart-budget-block">
-          <h3>问题 2：每月收入（禁止输入 0，以千为单位）</h3>
-          <div className="field">
-            <label htmlFor="income-k">示例：8 代表 8000 元</label>
-            <input
-              id="income-k"
-              type="number"
-              min={1}
-              step={1}
-              value={answers.monthlyIncomeK}
-              onChange={(event) =>
-                setAnswers((prev) => ({ ...prev, monthlyIncomeK: Number(event.target.value) }))
-              }
-            />
-          </div>
-        </div>
-      ) : null}
-
-      {step === 3 ? (
-        <div className="smart-budget-block">
-          <h3>问题 3：每月固定支出有多少（以千为单位）</h3>
-          <p>包含房租/房贷、固定账单、长期订阅等刚性成本。</p>
-          <div className="field">
-            <label htmlFor="fixed-expense-k">示例：3 代表 3000 元</label>
-            <input
-              id="fixed-expense-k"
-              type="number"
-              min={0}
-              step={0.5}
-              value={answers.monthlyFixedExpenseK}
-              onChange={(event) =>
-                setAnswers((prev) => ({
-                  ...prev,
-                  monthlyFixedExpenseK: Number(event.target.value)
-                }))
-              }
-            />
-          </div>
-        </div>
-      ) : null}
-
-      {step === 4 ? (
-        <div className="smart-budget-block">
-          <h3>问题 4：设置预算比例（快捷选择或滑动选择）</h3>
-          <p>该比例用于“可支配收入”中的储蓄/投资占比。</p>
-
-          <div className="smart-budget-ratio-options">
-            {ratioQuickOptions.map((ratio) => (
-              <button
-                key={ratio}
-                type="button"
-                className={answers.savingsRatio === ratio ? 'active' : ''}
-                onClick={() => setAnswers((prev) => ({ ...prev, savingsRatio: ratio }))}
-              >
-                {Math.round(ratio * 100)}%
-              </button>
-            ))}
-          </div>
-
-          <div className="field">
-            <label htmlFor="savings-ratio-range">
-              当前比例：{Math.round(answers.savingsRatio * 100)}%
-            </label>
-            <input
-              id="savings-ratio-range"
-              type="range"
-              min={10}
-              max={60}
-              step={1}
-              value={Math.round(answers.savingsRatio * 100)}
-              onChange={(event) =>
-                setAnswers((prev) => ({ ...prev, savingsRatio: Number(event.target.value) / 100 }))
-              }
-            />
-          </div>
-        </div>
-      ) : null}
-
-      {step === 5 && draftRecommendation ? (
-        <div className="smart-budget-block">
-          <h3>月分类预算推荐（可确认保存）</h3>
-          <p>{summary}</p>
-          <div className="smart-budget-result-grid">
-            <article className="smart-budget-stat-card">
-              <span>月收入</span>
-              <strong>{formatCurrency(draftRecommendation.monthlyIncome)}</strong>
-            </article>
-            <article className="smart-budget-stat-card">
-              <span>固定支出</span>
-              <strong>{formatCurrency(draftRecommendation.monthlyFixedExpense)}</strong>
-            </article>
-            <article className="smart-budget-stat-card">
-              <span>储蓄/投资</span>
-              <strong>{formatCurrency(draftRecommendation.savingsAmount)}</strong>
-            </article>
-            <article className="smart-budget-stat-card">
-              <span>灵活预算</span>
-              <strong>{formatCurrency(draftRecommendation.flexibleBudget)}</strong>
-            </article>
-          </div>
-
-          <div className="table-wrap">
-            <table className="table smart-budget-table">
-              <thead>
-                <tr>
-                  <th>分类</th>
-                  <th>金额</th>
-                  <th>占月收入比例</th>
-                </tr>
-              </thead>
-              <tbody>
-                {draftRecommendation.categoryBudgets.map((row) => (
-                  <tr key={row.category}>
-                    <td>{row.category}</td>
-                    <td>{formatCurrency(row.amount)}</td>
-                    <td>{(row.ratio * 100).toFixed(1)}%</td>
-                  </tr>
+            {visibleRows.length ? (
+              <div className="smart-budget-progress-list">
+                {visibleRows.map((item) => (
+                  <article key={item.category} className="smart-budget-progress-card">
+                    <header>
+                      <h4>{item.category}</h4>
+                      <span className={item.isOverspent ? 'warn' : 'safe'}>
+                        {item.isOverspent ? `超支 ${formatCurrency(item.diff)}` : '预算内'}
+                      </span>
+                    </header>
+                    <p>
+                      已花费 {formatCurrency(item.spentAmount)} / 预算{' '}
+                      {formatCurrency(item.budgetAmount)}
+                    </p>
+                    <div className="smart-budget-progress-track" aria-hidden="true">
+                      <span
+                        className={item.isOverspent ? 'warn' : ''}
+                        style={{ width: `${progressPercent(item.ratio)}%` }}
+                      />
+                    </div>
+                  </article>
                 ))}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="smart-budget-actions">
-            <button type="button" className="primary" onClick={handleConfirm}>
-              确认使用该预算建议
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setDraftRecommendation(null);
-                setStep(1);
-                setError(null);
-              }}
-            >
-              重新填写问答
-            </button>
-          </div>
-        </div>
+              </div>
+            ) : (
+              <p className="smart-budget-empty">当前筛选条件下暂无预算项，请切换月份或筛选条件。</p>
+            )}
+          </section>
+        ) : (
+          <p className="smart-budget-empty">请先完成预算设置并确认后，再查看智能预算管理。</p>
+        )
       ) : null}
 
-      {error ? <p className="smart-budget-error">{error}</p> : null}
+      {mode === 'setup' ? (
+        <>
+          <div className="smart-budget-stepper" aria-label="预算问答步骤">
+            {[1, 2, 3, 4, 5].map((value) => (
+              <span
+                key={value}
+                className={value === step ? 'active' : value < step ? 'done' : ''}
+                aria-current={value === step ? 'step' : undefined}
+              >
+                {value <= 4 ? `问题 ${value}` : '确认'}
+              </span>
+            ))}
+          </div>
 
-      <footer className="smart-budget-footer">
-        <button type="button" onClick={goPrev} disabled={step === 1}>
-          上一步
-        </button>
-        <button type="button" className="primary" onClick={goNext} disabled={step >= 5}>
-          {step === 4 ? '生成预算推荐' : '下一步'}
-        </button>
-      </footer>
+          {step === 1 ? (
+            <div className="smart-budget-block">
+              <h3>问题 1：你目前的身份是？</h3>
+              <div className="smart-budget-choice-grid">
+                {identityOptions.map((item) => (
+                  <label key={item.value} className="smart-budget-choice-card">
+                    <input
+                      type="radio"
+                      name="identity"
+                      value={item.value}
+                      checked={answers.identity === item.value}
+                      onChange={() => setAnswers((prev) => ({ ...prev, identity: item.value }))}
+                    />
+                    <strong>{item.label}</strong>
+                    <span>{item.helper}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ) : null}
 
-      {confirmedPlan ? (
-        <section className="smart-budget-confirmed panel">
-          <h3>已确认预算</h3>
-          <p>
-            最近确认时间：
-            {new Date(confirmedPlan.confirmedAt).toLocaleString('zh-CN', { hour12: false })}
-          </p>
-          <p>
-            身份：{getIdentityLabel(confirmedPlan.answers.identity)}，储蓄比例：
-            {Math.round(confirmedPlan.answers.savingsRatio * 100)}%
-          </p>
-          <button type="button" onClick={clearPlan}>
-            清除已确认预算
-          </button>
-        </section>
+          {step === 2 ? (
+            <div className="smart-budget-block">
+              <h3>问题 2：每月收入（禁止输入 0，以千为单位）</h3>
+              <div className="field">
+                <label htmlFor="income-k">示例：8 代表 8000 元</label>
+                <input
+                  id="income-k"
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={answers.monthlyIncomeK}
+                  onChange={(event) =>
+                    setAnswers((prev) => ({ ...prev, monthlyIncomeK: Number(event.target.value) }))
+                  }
+                />
+              </div>
+            </div>
+          ) : null}
+
+          {step === 3 ? (
+            <div className="smart-budget-block">
+              <h3>问题 3：每月固定支出有多少（以千为单位）</h3>
+              <p>包含房租/房贷、固定账单、长期订阅等刚性成本。</p>
+              <div className="field">
+                <label htmlFor="fixed-expense-k">示例：3 代表 3000 元</label>
+                <input
+                  id="fixed-expense-k"
+                  type="number"
+                  min={0}
+                  step={0.5}
+                  value={answers.monthlyFixedExpenseK}
+                  onChange={(event) =>
+                    setAnswers((prev) => ({
+                      ...prev,
+                      monthlyFixedExpenseK: Number(event.target.value)
+                    }))
+                  }
+                />
+              </div>
+            </div>
+          ) : null}
+
+          {step === 4 ? (
+            <div className="smart-budget-block">
+              <h3>问题 4：设置预算比例（快捷选择或滑动选择）</h3>
+              <p>该比例用于“可支配收入”中的储蓄/投资占比。</p>
+
+              <div className="smart-budget-ratio-options">
+                {ratioQuickOptions.map((ratio) => (
+                  <button
+                    key={ratio}
+                    type="button"
+                    className={answers.savingsRatio === ratio ? 'active' : ''}
+                    onClick={() => setAnswers((prev) => ({ ...prev, savingsRatio: ratio }))}
+                  >
+                    {Math.round(ratio * 100)}%
+                  </button>
+                ))}
+              </div>
+
+              <div className="field">
+                <label htmlFor="savings-ratio-range">
+                  当前比例：{Math.round(answers.savingsRatio * 100)}%
+                </label>
+                <input
+                  id="savings-ratio-range"
+                  type="range"
+                  min={10}
+                  max={60}
+                  step={1}
+                  value={Math.round(answers.savingsRatio * 100)}
+                  onChange={(event) =>
+                    setAnswers((prev) => ({
+                      ...prev,
+                      savingsRatio: Number(event.target.value) / 100
+                    }))
+                  }
+                />
+              </div>
+            </div>
+          ) : null}
+
+          {step === 5 && draftRecommendation ? (
+            <div className="smart-budget-block">
+              <h3>月分类预算推荐（可确认保存）</h3>
+              <p>{summary}</p>
+              <div className="smart-budget-result-grid">
+                <article className="smart-budget-stat-card">
+                  <span>月收入</span>
+                  <strong>{formatCurrency(draftRecommendation.monthlyIncome)}</strong>
+                </article>
+                <article className="smart-budget-stat-card">
+                  <span>固定支出</span>
+                  <strong>{formatCurrency(draftRecommendation.monthlyFixedExpense)}</strong>
+                </article>
+                <article className="smart-budget-stat-card">
+                  <span>储蓄/投资</span>
+                  <strong>{formatCurrency(draftRecommendation.savingsAmount)}</strong>
+                </article>
+                <article className="smart-budget-stat-card">
+                  <span>灵活预算</span>
+                  <strong>{formatCurrency(draftRecommendation.flexibleBudget)}</strong>
+                </article>
+              </div>
+
+              <div className="table-wrap">
+                <table className="table smart-budget-table">
+                  <thead>
+                    <tr>
+                      <th>分类</th>
+                      <th>金额</th>
+                      <th>占月收入比例</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {draftRecommendation.categoryBudgets.map((row) => (
+                      <tr key={row.category}>
+                        <td>{row.category}</td>
+                        <td>{formatCurrency(row.amount)}</td>
+                        <td>{(row.ratio * 100).toFixed(1)}%</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="smart-budget-actions">
+                <button type="button" className="primary" onClick={handleConfirm}>
+                  确认使用该预算建议
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDraftRecommendation(null);
+                    setStep(1);
+                    setError(null);
+                  }}
+                >
+                  重新填写问答
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {error ? <p className="smart-budget-error">{error}</p> : null}
+
+          <footer className="smart-budget-footer">
+            <button type="button" onClick={goPrev} disabled={step === 1}>
+              上一步
+            </button>
+            <button type="button" className="primary" onClick={goNext} disabled={step >= 5}>
+              {step === 4 ? '生成预算推荐' : '下一步'}
+            </button>
+          </footer>
+
+          {confirmedPlan ? (
+            <section className="smart-budget-confirmed panel">
+              <h3>已确认预算</h3>
+              <p>
+                最近确认时间：
+                {new Date(confirmedPlan.confirmedAt).toLocaleString('zh-CN', { hour12: false })}
+              </p>
+              <p>
+                身份：{getIdentityLabel(confirmedPlan.answers.identity)}，储蓄比例：
+                {Math.round(confirmedPlan.answers.savingsRatio * 100)}%
+              </p>
+              <button type="button" onClick={clearPlan}>
+                清除已确认预算
+              </button>
+            </section>
+          ) : null}
+        </>
       ) : null}
     </section>
   );


### PR DESCRIPTION
### Motivation
- Provide a management view after budget confirmation so users can see recent months' execution and which categories are overspent. 
- Make controls dynamic and the UI more intuitive with clear visual feedback for overspend status. 
- Keep the existing 4-step budget setup flow while adding a post-confirmation dashboard for monitoring. 

### Description
- Add `budgetInsights` helpers to compute recent month options and per-category tracking rows (diff, ratio, overspent) from a confirmed `BudgetRecommendation` and transactions (`src/features/smart-budget/model/budgetInsights.ts`).
- Extend `SmartBudgetPage` to a two-mode flow (`setup` / `management`), add month selector, status filters (`全部/已超支/正常`), and progress cards showing per-category spend vs. budget and overspend highlights (`src/pages/smart-budget/SmartBudgetPage.tsx`).
- Add unit tests for `budgetInsights` behavior (`src/features/smart-budget/model/budgetInsights.test.ts`) and accompanying styles for the management dashboard (`src/app/styles/global.css`).
- Keep original recommendation wizard and wire confirmation to persist the confirmed plan and switch to management mode via the existing `useSmartBudgetStore` and `useFinanceStore` stores.

### Testing
- Ran unit tests with `vitest` for budget insights and planner, and they all passed (`2 files, 5 tests`, green).
- Ran linting (`npx eslint`) and formatting (`prettier --write`) as part of pre-commit checks and fixed style issues.
- Built the production bundle with `npm run build` (Vite) and the build completed successfully.
- Performed an automated UI smoke run with Playwright against the dev server to capture a management-page screenshot, which completed and produced `artifacts/smart-budget-management.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699130c40b808331b2f713cfab3e3b3d)