### PR TITLE
feat: make category and tag count chips navigable

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -4719,6 +4719,16 @@ small.mono {
   background: var(--color-bg-subtle);
 }
 
+.tag-count-chip-link {
+  cursor: pointer;
+}
+
+.tag-count-chip-link:hover {
+  color: var(--color-primary-700);
+  border-color: color-mix(in srgb, var(--color-primary-500) 40%, var(--color-border-light));
+  background: color-mix(in srgb, var(--color-primary-50) 70%, var(--color-bg-subtle));
+}
+
 .account-card-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));

--- a/src/pages/categories-accounts/CategoriesAccountsPage.tsx
+++ b/src/pages/categories-accounts/CategoriesAccountsPage.tsx
@@ -261,18 +261,17 @@ export function CategoriesAccountsPage() {
                 <li key={item.id} className="row categories-row">
                   <span style={{ flex: 1 }}>
                     {item.name}
-                    <small className="tag-count-chip">
+                    <button
+                      type="button"
+                      className="tag-count-chip tag-count-chip-link"
+                      onClick={() =>
+                        navigate(`/transactions?categoryId=${encodeURIComponent(item.id)}`)
+                      }
+                      aria-label={`查看分类 ${item.name} 的 ${categoryUsageMap.get(item.id) || 0} 条交易`}
+                    >
                       {categoryUsageMap.get(item.id) || 0} 条
-                    </small>
+                    </button>
                   </span>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      navigate(`/transactions?categoryId=${encodeURIComponent(item.id)}`)
-                    }
-                  >
-                    快捷查看
-                  </button>
                   <button type="button" className="danger" onClick={() => removeCategory(item.id)}>
                     删除
                   </button>
@@ -306,7 +305,16 @@ export function CategoriesAccountsPage() {
                 <li key={tag.key} className="row categories-row">
                   <span style={{ flex: 1 }}>
                     #{tag.label}
-                    <small className="tag-count-chip">{tag.count} 条</small>
+                    <button
+                      type="button"
+                      className="tag-count-chip tag-count-chip-link"
+                      onClick={() =>
+                        navigate(`/transactions?keyword=${encodeURIComponent(tag.label)}`)
+                      }
+                      aria-label={`查看标签 ${tag.label} 的 ${tag.count} 条交易`}
+                    >
+                      {tag.count} 条
+                    </button>
                   </span>
                   <button
                     type="button"


### PR DESCRIPTION
### Motivation
- Improve discoverability by making the count chips in 分类与标签管理 directly actionable so users can jump to filtered transactions by clicking the count instead of using a separate “快捷查看” control.
- Keep the existing visual language of the chips while making the interaction accessible and discoverable.

### Description
- Replaced the standalone “快捷查看” action for categories by turning the category count chip into a clickable `<button>` that navigates to `/transactions?categoryId=...` and added an `aria-label` for accessibility (file: `src/pages/categories-accounts/CategoriesAccountsPage.tsx`).
- Converted tag count chips into clickable buttons that navigate to `/transactions?keyword=...` to filter by tag (file: `src/pages/categories-accounts/CategoriesAccountsPage.tsx`).
- Added `.tag-count-chip-link` CSS rules to indicate interactivity and provide hover styling for the clickable chips (file: `src/app/styles/global.css`).
- Preserved the original chip appearance and removed the now-redundant separate category “快捷查看” button.

### Testing
- Ran `npm run lint` which completed successfully with no errors.
- Launched the dev server with `npm run dev` and verified the updated UI by loading `/categories-accounts` and capturing a screenshot using Playwright to confirm the clickable chips and hover styles render as expected.
- No unit test changes were required and existing test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991b0952e248331801b226c72ccdc1d)