### PR TITLE
feat(exchange): show up/down/flat icons for exchange rate changes

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -4125,6 +4125,24 @@ small.mono {
   line-height: 1;
 }
 
+.exchange-rate-trend {
+  margin-left: var(--space-2);
+  font-size: var(--font-xs);
+  white-space: nowrap;
+}
+
+.exchange-rate-trend-up {
+  color: var(--color-success);
+}
+
+.exchange-rate-trend-down {
+  color: var(--color-danger);
+}
+
+.exchange-rate-trend-flat {
+  color: var(--color-text-secondary);
+}
+
 .exchange-pagination {
   display: flex;
   align-items: center;

--- a/src/features/exchange/hooks/useExchangeRates.ts
+++ b/src/features/exchange/hooks/useExchangeRates.ts
@@ -23,9 +23,23 @@ interface UseExchangeRatesReturn {
   refresh: () => void;
 }
 
-function toSortedRates(ratesMap: Record<string, number>): ExchangeRate[] {
+function toSortedRates(
+  ratesMap: Record<string, number>,
+  previousMap?: Record<string, number>
+): ExchangeRate[] {
   return Object.entries(ratesMap)
-    .map(([code, rate]) => ({ code, name: getCurrencyName(code), rate }))
+    .map(([code, rate]) => {
+      const previousRate = previousMap?.[code];
+      const trend: ExchangeRate['trend'] =
+        typeof previousRate !== 'number'
+          ? undefined
+          : rate > previousRate
+            ? 'up'
+            : rate < previousRate
+              ? 'down'
+              : 'flat';
+      return { code, name: getCurrencyName(code), rate, trend };
+    })
     .sort((a, b) => a.code.localeCompare(b.code));
 }
 
@@ -37,6 +51,7 @@ export function useExchangeRates(initialBase = 'CNY'): UseExchangeRatesReturn {
   const [error, setError] = useState<string | null>(null);
   const [fromCache, setFromCache] = useState(false);
   const mountedRef = useRef(true);
+  const latestRatesMapRef = useRef<Record<string, number>>({});
 
   const load = useCallback(
     async (forceRefresh = false) => {
@@ -47,6 +62,7 @@ export function useExchangeRates(initialBase = 'CNY'): UseExchangeRatesReturn {
       if (!forceRefresh) {
         const cached = readCache(base);
         if (cached) {
+          latestRatesMapRef.current = cached.rates;
           setRates(toSortedRates(cached.rates));
           setDate(cached.date);
           setFromCache(true);
@@ -60,7 +76,8 @@ export function useExchangeRates(initialBase = 'CNY'): UseExchangeRatesReturn {
         const data = await fetchLatestRates(base);
         if (!mountedRef.current) return;
         writeCache(base, data.date, data.rates);
-        setRates(toSortedRates(data.rates));
+        setRates(toSortedRates(data.rates, latestRatesMapRef.current));
+        latestRatesMapRef.current = data.rates;
         setDate(data.date);
         setFromCache(false);
       } catch (err) {
@@ -68,6 +85,7 @@ export function useExchangeRates(initialBase = 'CNY'): UseExchangeRatesReturn {
         // 3. 离线回退：尝试过期缓存
         const stale = readCache(base);
         if (stale) {
+          latestRatesMapRef.current = stale.rates;
           setRates(toSortedRates(stale.rates));
           setDate(stale.date);
           setFromCache(true);
@@ -83,6 +101,7 @@ export function useExchangeRates(initialBase = 'CNY'): UseExchangeRatesReturn {
 
   useEffect(() => {
     mountedRef.current = true;
+    latestRatesMapRef.current = {};
     void load();
     return () => {
       mountedRef.current = false;

--- a/src/features/exchange/model/types.ts
+++ b/src/features/exchange/model/types.ts
@@ -8,6 +8,8 @@ export interface ExchangeRate {
   name: string;
   /** 相对于基准货币的汇率 */
   rate: number;
+  /** 相比上一次数据的变动方向 */
+  trend?: 'up' | 'down' | 'flat';
 }
 
 /** API 返回的原始数据结构（frankfurter.app 格式） */

--- a/src/features/exchange/ui/ExchangeRateTable.test.tsx
+++ b/src/features/exchange/ui/ExchangeRateTable.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ExchangeRateTable } from './ExchangeRateTable';
+import type { ExchangeRate } from '../model/types';
+
+const baseProps = {
+  base: 'CNY',
+  date: '2026-02-15',
+  fromCache: false,
+  loading: false,
+  error: null,
+  onRefresh: vi.fn()
+};
+
+describe('ExchangeRateTable', () => {
+  it('应为涨跌和持平展示对应图标', () => {
+    const rates: ExchangeRate[] = [
+      { code: 'USD', name: '美元', rate: 0.1399, trend: 'up' },
+      { code: 'EUR', name: '欧元', rate: 0.1288, trend: 'down' },
+      { code: 'JPY', name: '日元', rate: 21.53, trend: 'flat' }
+    ];
+
+    render(<ExchangeRateTable rates={rates} {...baseProps} />);
+
+    expect(screen.getByText('⬆️ 上涨')).toBeInTheDocument();
+    expect(screen.getByText('⬇️ 下跌')).toBeInTheDocument();
+    expect(screen.getByText('⟷ 持平')).toBeInTheDocument();
+  });
+
+  it('首次加载无趋势数据时不展示图标', () => {
+    const rates: ExchangeRate[] = [{ code: 'USD', name: '美元', rate: 0.1399 }];
+
+    render(<ExchangeRateTable rates={rates} {...baseProps} />);
+
+    expect(screen.queryByText('上涨')).not.toBeInTheDocument();
+    expect(screen.queryByText('下跌')).not.toBeInTheDocument();
+    expect(screen.queryByText('持平')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/exchange/ui/ExchangeRateTable.tsx
+++ b/src/features/exchange/ui/ExchangeRateTable.tsx
@@ -14,6 +14,18 @@ interface ExchangeRateTableProps {
 
 const PAGE_SIZE = 20;
 
+const TREND_ICON: Record<NonNullable<ExchangeRate['trend']>, string> = {
+  up: '⬆️',
+  down: '⬇️',
+  flat: '⟷'
+};
+
+const TREND_LABEL: Record<NonNullable<ExchangeRate['trend']>, string> = {
+  up: '上涨',
+  down: '下跌',
+  flat: '持平'
+};
+
 export function ExchangeRateTable({
   rates,
   base,
@@ -127,7 +139,12 @@ export function ExchangeRateTable({
                 </td>
                 <td>{r.name}</td>
                 <td style={{ textAlign: 'right' }} className="mono-inline">
-                  {r.rate.toFixed(r.rate < 1 ? 6 : 4)}
+                  <span>{r.rate.toFixed(r.rate < 1 ? 6 : 4)}</span>
+                  {r.trend ? (
+                    <span className={`exchange-rate-trend exchange-rate-trend-${r.trend}`}>
+                      {TREND_ICON[r.trend]} {TREND_LABEL[r.trend]}
+                    </span>
+                  ) : null}
                 </td>
               </tr>
             ))


### PR DESCRIPTION
### Motivation
- 为汇率列表添加可视化的“上涨/下跌/持平”标记以便用户快速识别币种走势。 

### Description
- 在 `ExchangeRate` 类型中新增可选字段 `trend?: 'up' | 'down' | 'flat'` 用于表示相对上一次数据的变动方向 (`src/features/exchange/model/types.ts`).
- 在 `useExchangeRates` 中添加历史快照比较逻辑，通过 `latestRatesMapRef` 在刷新/请求新数据时与上一份速率对比并生成 `trend`，并在基准切换时重置比较基线 (`src/features/exchange/hooks/useExchangeRates.ts`).
- 在 `ExchangeRateTable` 中渲染对应的图标与文案（`⬆️ 上涨` / `⬇️ 下跌` / `⟷ 持平`），仅在有可比历史数据时显示，并新增单元测试覆盖展示与首次无趋势的情况 (`src/features/exchange/ui/ExchangeRateTable.tsx`, `src/features/exchange/ui/ExchangeRateTable.test.tsx`).
- 增加样式类以区别涨跌持平颜色与间距 (`src/app/styles/global.css`).

### Testing
- 运行单测 `npm run test -- src/features/exchange/ui/ExchangeRateTable.test.tsx`，结果：`1 file, 2 tests` 均通过。
- 运行静态检查 `npm run lint`，结果：通过（无错误）。
- 运行构建 `npm run build`，结果：构建成功（`vite build` 完成）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991b0c270888331a5d1a35688403fbc)