### PR TITLE
fix(transactions): improve AI recategorize feedback visibility

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -3478,7 +3478,7 @@ small.mono {
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-lg);
   font-size: var(--font-sm);
-  z-index: 200;
+  z-index: 420;
   animation: toast-in 0.25s ease both;
   max-width: 360px;
 }

--- a/src/features/transactions/components/TransactionDetailDrawer.tsx
+++ b/src/features/transactions/components/TransactionDetailDrawer.tsx
@@ -41,6 +41,7 @@ interface TransactionDetailDrawerProps {
   onCopyJson: () => void;
   onDelete: () => void;
   onAiRecategorize: () => void;
+  aiRecategorizing?: boolean;
   visibleSections: Record<TransactionDetailSectionKey, boolean>;
   onToggleSection: (key: TransactionDetailSectionKey) => void;
 }
@@ -56,6 +57,7 @@ export function TransactionDetailDrawer({
   onCopyJson,
   onDelete,
   onAiRecategorize,
+  aiRecategorizing = false,
   visibleSections,
   onToggleSection
 }: TransactionDetailDrawerProps) {
@@ -304,8 +306,8 @@ export function TransactionDetailDrawer({
           <Link to={`/transactions/${transaction.id}`} style={{ textDecoration: 'none' }}>
             <button type="button">✏️ 编辑</button>
           </Link>
-          <button type="button" onClick={onAiRecategorize}>
-            🤖 AI 重分类
+          <button type="button" onClick={onAiRecategorize} disabled={aiRecategorizing}>
+            {aiRecategorizing ? '🤖 AI 重分类中…' : '🤖 AI 重分类'}
           </button>
           <button type="button" className="danger" onClick={onDelete}>
             🗑️ 删除

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -316,6 +316,7 @@ export function TransactionsPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [pendingDeleteIds, setPendingDeleteIds] = useState<string[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [aiRecategorizingId, setAiRecategorizingId] = useState<string | null>(null);
   const [bulkSelectionEnabled, setBulkSelectionEnabled] = useState(false);
   const [highlightId, setHighlightId] = useState<string>('');
   const [importNotice, setImportNotice] = useState<{
@@ -1083,6 +1084,8 @@ export function TransactionsPage() {
         onAiRecategorize={() => {
           if (!selected) return;
 
+          setAiRecategorizingId(selected.id);
+
           const fallbackRecategorize = () => {
             const nextCategoryId = inferCategoryIdByTransaction(
               selected,
@@ -1091,10 +1094,12 @@ export function TransactionsPage() {
             );
             if (!nextCategoryId || nextCategoryId === selected.categoryId) {
               showToast('AI 分类建议未变化，无需替换。', 'warning');
+              setAiRecategorizingId(null);
               return;
             }
             updateTransaction(selected.id, { ...selected, categoryId: nextCategoryId });
             showToast('已按账单信息完成 AI 重分类。', 'success');
+            setAiRecategorizingId(null);
           };
 
           const hasAiConfig =
@@ -1142,11 +1147,13 @@ export function TransactionsPage() {
               }
               updateTransaction(selected.id, { ...selected, categoryId: matched.id });
               showToast('已按大模型建议完成重分类。', 'success');
+              setAiRecategorizingId(null);
             })
             .catch(() => {
               fallbackRecategorize();
             });
         }}
+        aiRecategorizing={selected ? aiRecategorizingId === selected.id : false}
         visibleSections={visibleDetailSections}
         onToggleSection={handleToggleDetailSection}
       />


### PR DESCRIPTION
### Motivation

- 修复 AI 重分类的状态提示常被交易详情抽屉遮挡导致看起来无效的问题。 

### Description

- 将全局 `Toast` 层级从 `z-index: 200` 提升到 `z-index: 420`，确保通知会显示在详情抽屉之上。 
- 在 `TransactionsPage` 中新增 `aiRecategorizingId` 状态以跟踪正在进行的 AI 重分类请求，并在开始/完成/回退路径中设置与清理该状态。 
- 在 `TransactionDetailDrawer` 中新增可选 `aiRecategorizing` 属性，将 AI 重分类按钮在请求进行时禁用并将文案切换为 `🤖 AI 重分类中…`，提供明确的本地反馈。 
- 修改的文件：`src/app/styles/global.css`、`src/pages/transactions/TransactionsPage.tsx`、`src/features/transactions/components/TransactionDetailDrawer.tsx`。 

### Testing

- 运行单元测试 `npm test -- src/features/transactions/components/TransactionDetailDrawer.test.tsx`，结果通过。 
- 运行构建 `npm run build`，构建成功。 
- 在本地开发服务器手动检查 `/transactions` 页面并生成截图以验证提示与抽屉的可见性（手动检查成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991b70a4a74833182e3409185cb0af2)