### PR TITLE
fix: 将交易列表的分类筛选改为下拉框

### DIFF
--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -478,6 +478,21 @@ export function TransactionTable({
                             onChange={(event) => onQuickFilterChange('date', event.target.value)}
                             placeholder="筛选日期"
                           />
+                        ) : column.key === 'category' ? (
+                          <select
+                            aria-label="按分类筛选"
+                            value={quickFilters.category}
+                            onChange={(event) =>
+                              onQuickFilterChange('category', event.target.value)
+                            }
+                          >
+                            <option value="">全部分类</option>
+                            {categoryOptions.map((option) => (
+                              <option key={option.id} value={option.id}>
+                                {option.name}
+                              </option>
+                            ))}
+                          </select>
                         ) : column.key === 'amount' ? (
                           <div className="transaction-amount-range-inputs">
                             <input

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -487,7 +487,7 @@ export function TransactionsPage() {
 
   const quickFilteredRows = useMemo(() => {
     const dateFilter = quickFilters.date.trim().toLowerCase();
-    const categoryFilter = quickFilters.category.trim().toLowerCase();
+    const categoryFilter = quickFilters.category.trim();
     const accountFilter = quickFilters.account.trim().toLowerCase();
     const amountMinRaw = quickFilters.amountMin.trim();
     const amountMaxRaw = quickFilters.amountMax.trim();
@@ -509,8 +509,7 @@ export function TransactionsPage() {
     return mappedRows.filter((row) => {
       const dateText = formatDate(row.item.date).toLowerCase();
       const typePass = quickFilters.type === 'all' ? true : row.item.type === quickFilters.type;
-      const categoryPass =
-        !categoryFilter || row.categoryName.toLowerCase().includes(categoryFilter);
+      const categoryPass = !categoryFilter || row.item.categoryId === categoryFilter;
       const accountPass = !accountFilter || row.accountName.toLowerCase().includes(accountFilter);
       const orderNoPass =
         !orderNoFilter || (row.item.orderNo || '').toLowerCase().includes(orderNoFilter);


### PR DESCRIPTION
### Motivation
- 账单/交易页的“分类”筛选应为下拉选择而非文本搜索，以便用户从已有分类中直接选择并避免模糊匹配导致的误筛选。

### Description
- 在 `src/features/transactions/components/TransactionTable.tsx` 中将表头快速筛选的“分类”列由文本输入改为使用 `select` 下拉，选项来源于传入的 `categoryOptions`，并增加空值项显示为 `全部分类`。
- 在 `src/pages/transactions/TransactionsPage.tsx` 的快速筛选逻辑中将分类匹配由名称模糊匹配改为按 `categoryId` 精确匹配以配合下拉框的值。
- 保持其他快速筛选（金额、日期、类型等）行为不变，并保留对空金额输入的兼容判断以避免误判。

### Testing
- 运行构建：`npm run build` 成功（TypeScript 校验 + Vite 打包通过）。
- 启动开发服务器：`npm run dev -- --host 0.0.0.0 --port 4173`，Vite 成功就绪并可访问。 
- 使用 Playwright 脚本访问 `http://127.0.0.1:4173/transactions` 并截取页面截图以验证 UI 已渲染并显示分类下拉。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991b7548c188331ba9cda0360a954a8)