### PR TITLE
fix: keep transaction filters visible for empty filtered results

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -1156,6 +1156,19 @@ tr:hover td {
   cursor: pointer;
 }
 
+.transaction-empty-cell {
+  text-align: center;
+  padding: 24px 16px;
+}
+
+.transaction-empty-inline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--color-text-secondary);
+}
+
 .transaction-row-actions {
   white-space: nowrap;
 }

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -183,6 +183,9 @@ export function TransactionTable({
   const orderedColumns = columnOrder
     .map((key) => columnOptions.find((item) => item.key === key))
     .filter((item): item is { key: TransactionColumnKey; label: string } => Boolean(item));
+  const visibleColumnCount =
+    orderedColumns.filter((column) => visibleColumns[column.key]).length +
+    (bulkSelectionEnabled ? 1 : 0);
 
   const renderCellValue = (columnKey: TransactionColumnKey, row: TransactionRowView) => {
     const { item, categoryName, accountName } = row;
@@ -297,7 +300,7 @@ export function TransactionTable({
           secondaryAction={{ label: '清空筛选', onClick: onClearFilters }}
           primaryAction={{ label: '重试', onClick: onRetry, variant: 'primary' }}
         />
-      ) : rows.length === 0 ? (
+      ) : rows.length === 0 && !hasFilters ? (
         <EmptyState
           icon="📋"
           title={hasFilters ? '没有符合条件的交易' : '暂无交易记录'}
@@ -523,101 +526,114 @@ export function TransactionTable({
                 </tr>
               </thead>
               <tbody>
-                {rows.map(({ item, categoryName, accountName }) => {
-                  const note = item.note || '-';
-                  const checked = selectedIds.includes(item.id);
-                  return (
-                    <tr
-                      key={item.id}
-                      id={`transaction-row-${item.id}`}
-                      className={`transaction-row-clickable ${highlightId === item.id ? 'transaction-row-highlight' : ''}`.trim()}
-                      onClick={() => onOpenDetail(item.id)}
-                      onContextMenu={(event) => {
-                        event.preventDefault();
-                        setContextMenu({ x: event.clientX, y: event.clientY, id: item.id });
-                      }}
-                    >
-                      {bulkSelectionEnabled ? (
-                        <td
-                          className="transaction-select-col"
-                          onClick={(event) => event.stopPropagation()}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={(event) => onToggleSelect(item.id, event.target.checked)}
-                            aria-label={`选择交易 ${formatDate(item.date)} ${item.note || ''}`}
-                          />
-                        </td>
-                      ) : null}
-                      {orderedColumns.map((column) => {
-                        if (!visibleColumns[column.key]) return null;
-                        if (column.key === 'type') {
-                          return (
-                            <td key={`${item.id}-${column.key}`}>
-                              <span
-                                className={
-                                  item.type === 'income'
-                                    ? 'badge badge-success'
-                                    : 'badge badge-danger'
-                                }
+                {rows.length === 0 ? (
+                  <tr>
+                    <td colSpan={visibleColumnCount} className="transaction-empty-cell">
+                      <div className="transaction-empty-inline">
+                        <span>没有符合条件的交易，调整筛选条件后重试。</span>
+                        <button type="button" onClick={onClearFilters}>
+                          清空筛选
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ) : (
+                  rows.map(({ item, categoryName, accountName }) => {
+                    const note = item.note || '-';
+                    const checked = selectedIds.includes(item.id);
+                    return (
+                      <tr
+                        key={item.id}
+                        id={`transaction-row-${item.id}`}
+                        className={`transaction-row-clickable ${highlightId === item.id ? 'transaction-row-highlight' : ''}`.trim()}
+                        onClick={() => onOpenDetail(item.id)}
+                        onContextMenu={(event) => {
+                          event.preventDefault();
+                          setContextMenu({ x: event.clientX, y: event.clientY, id: item.id });
+                        }}
+                      >
+                        {bulkSelectionEnabled ? (
+                          <td
+                            className="transaction-select-col"
+                            onClick={(event) => event.stopPropagation()}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={(event) => onToggleSelect(item.id, event.target.checked)}
+                              aria-label={`选择交易 ${formatDate(item.date)} ${item.note || ''}`}
+                            />
+                          </td>
+                        ) : null}
+                        {orderedColumns.map((column) => {
+                          if (!visibleColumns[column.key]) return null;
+                          if (column.key === 'type') {
+                            return (
+                              <td key={`${item.id}-${column.key}`}>
+                                <span
+                                  className={
+                                    item.type === 'income'
+                                      ? 'badge badge-success'
+                                      : 'badge badge-danger'
+                                  }
+                                >
+                                  {renderCellValue(column.key, { item, categoryName, accountName })}
+                                </span>
+                              </td>
+                            );
+                          }
+                          if (column.key === 'amount') {
+                            return (
+                              <td
+                                key={`${item.id}-${column.key}`}
+                                style={{
+                                  fontWeight: 600,
+                                  color:
+                                    item.type === 'income'
+                                      ? 'var(--color-income)'
+                                      : 'var(--color-expense)'
+                                }}
                               >
                                 {renderCellValue(column.key, { item, categoryName, accountName })}
-                              </span>
-                            </td>
-                          );
-                        }
-                        if (column.key === 'amount') {
+                              </td>
+                            );
+                          }
+                          if (column.key === 'note') {
+                            return (
+                              <td key={`${item.id}-${column.key}`}>
+                                <span title={note}>
+                                  {renderCellValue(column.key, { item, categoryName, accountName })}
+                                </span>
+                              </td>
+                            );
+                          }
+                          if (column.key === 'orderNo' || column.key === 'merchantOrderNo') {
+                            const orderText = renderCellValue(column.key, {
+                              item,
+                              categoryName,
+                              accountName
+                            });
+                            return (
+                              <td key={`${item.id}-${column.key}`}>
+                                <span
+                                  className="transaction-order-ellipsis"
+                                  title={String(orderText)}
+                                >
+                                  {orderText === '-' ? '-' : truncateOrderNo(String(orderText))}
+                                </span>
+                              </td>
+                            );
+                          }
                           return (
-                            <td
-                              key={`${item.id}-${column.key}`}
-                              style={{
-                                fontWeight: 600,
-                                color:
-                                  item.type === 'income'
-                                    ? 'var(--color-income)'
-                                    : 'var(--color-expense)'
-                              }}
-                            >
+                            <td key={`${item.id}-${column.key}`}>
                               {renderCellValue(column.key, { item, categoryName, accountName })}
                             </td>
                           );
-                        }
-                        if (column.key === 'note') {
-                          return (
-                            <td key={`${item.id}-${column.key}`}>
-                              <span title={note}>
-                                {renderCellValue(column.key, { item, categoryName, accountName })}
-                              </span>
-                            </td>
-                          );
-                        }
-                        if (column.key === 'orderNo' || column.key === 'merchantOrderNo') {
-                          const orderText = renderCellValue(column.key, {
-                            item,
-                            categoryName,
-                            accountName
-                          });
-                          return (
-                            <td key={`${item.id}-${column.key}`}>
-                              <span
-                                className="transaction-order-ellipsis"
-                                title={String(orderText)}
-                              >
-                                {orderText === '-' ? '-' : truncateOrderNo(String(orderText))}
-                              </span>
-                            </td>
-                          );
-                        }
-                        return (
-                          <td key={`${item.id}-${column.key}`}>
-                            {renderCellValue(column.key, { item, categoryName, accountName })}
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  );
-                })}
+                        })}
+                      </tr>
+                    );
+                  })
+                )}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
### Motivation
- Avoid hiding the transaction filter row when the current filters produce zero results to prevent losing the filter UI and improve discoverability. 
- Show the full-page `EmptyState` only when there are truly no transactions and no active filters so users can still adjust filters in-place.

### Description
- Change empty-state branch to show full-page `EmptyState` only when `rows.length === 0 && !hasFilters`. 
- Add `visibleColumnCount` calculation to compute `colSpan` (accounts for visible columns and bulk-select column) so an inline empty row can span the correct width. 
- Render an inline empty-result row inside the table `tbody` when filters return no rows, showing a message and a `清空筛选` button that calls `onClearFilters`. 
- Add CSS rules (`.transaction-empty-cell` and `.transaction-empty-inline`) for centering and styling the inline empty-result content.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run test` (Vitest) and all tests passed (test suite completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991b788f63c833183167ce57b6a4b05)