### PR TITLE
fix(assistant): clear chat input immediately after submit

### DIFF
--- a/src/pages/assistant/AssistantPage.tsx
+++ b/src/pages/assistant/AssistantPage.tsx
@@ -397,6 +397,7 @@ export function AssistantPage() {
     if (!clean || wb.status === 'recognizing') return;
     pendingRequestModeRef.current = mode;
     setChatHistory((prev) => [...prev, { id: `${Date.now()}-user`, role: 'user', text: clean }]);
+    wb.setTextInput('');
     void wb.handleRecognizeWithPrompt(clean);
   };
 


### PR DESCRIPTION
### Motivation
- Ensure the chat input is cleared immediately after the user submits a prompt so the UI reflects that the message was sent without waiting for the async recognition flow.

### Description
- Call `wb.setTextInput('')` in `submitPrompt` in `src/pages/assistant/AssistantPage.tsx` so the textarea is cleared right after enqueuing the request.

### Testing
- Ran `npm run lint` and it passed.
- Ran an automated Playwright verification using Firefox that submits the assistant form and asserted the textarea value is empty (`textarea_value_after_submit: ''`), which succeeded and produced a screenshot artifact.
- Attempted the same Playwright run with Chromium which timed out/crashed (failure), but Firefox run confirmed the behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991bd4722e483318b166f8e5638da7c)