### PR TITLE
fix(finance): 修复负债与资讯板块重叠并接入 AI 还款建议

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -5992,3 +5992,55 @@ small.mono {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+.page-stack {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  padding: var(--space-4);
+}
+
+.finance-page {
+  align-content: start;
+}
+
+.finance-debt-form-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1.4fr) repeat(4, minmax(0, 1fr)) auto;
+}
+
+.finance-feed-form-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr) auto;
+  align-items: center;
+}
+
+.finance-ai-result {
+  margin: 10px 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--color-bg-subtle);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  padding: 10px;
+}
+
+@media (max-width: 1120px) {
+  .finance-debt-form-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .finance-debt-form-grid,
+  .finance-feed-form-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/pages/finance/FinancePage.tsx
+++ b/src/pages/finance/FinancePage.tsx
@@ -1,10 +1,12 @@
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { useAppPreferences } from '../../shared/store/useAppPreferences';
+import { useAiSettings } from '../../shared/store/useAiSettings';
 import {
   calculateDebtMinimumPayment,
   calculateDebtSummary,
   DebtType
 } from '../../features/debt/model/debtMetrics';
+import { sendAiChat } from '../../features/assistant/api/openaiCompatibleClient';
 
 type FinanceNewsItem = {
   id: string;
@@ -115,6 +117,7 @@ export function FinancePage() {
     addDebt,
     removeDebt
   } = useAppPreferences();
+  const { baseUrl, apiKey, model } = useAiSettings();
   const [news, setNews] = useState<FinanceNewsItem[]>(() => {
     if (typeof window === 'undefined') return [];
     const cachedRaw = window.localStorage.getItem(FINANCE_NEWS_CACHE_KEY);
@@ -137,6 +140,9 @@ export function FinancePage() {
   const [debtBalance, setDebtBalance] = useState('');
   const [debtAnnualRate, setDebtAnnualRate] = useState('');
   const [debtMonths, setDebtMonths] = useState('');
+  const [repaymentAdvice, setRepaymentAdvice] = useState('');
+  const [repaymentReasoning, setRepaymentReasoning] = useState('');
+  const [repaymentLoading, setRepaymentLoading] = useState(false);
 
   const enabledFeeds = useMemo(
     () => rssSubscriptions.filter((item) => item.enabled),
@@ -241,8 +247,54 @@ export function FinancePage() {
     setDebtMonths('');
   }
 
+  async function onGenerateRepaymentAdvice() {
+    if (debts.length === 0) {
+      setError('请先新增至少一条负债记录，再让 AI 生成建议。');
+      return;
+    }
+
+    setError('');
+    setRepaymentAdvice('');
+    setRepaymentReasoning('');
+    setRepaymentLoading(true);
+
+    try {
+      const debtLines = debts
+        .map((item) => {
+          const minimum = calculateDebtMinimumPayment(item);
+          const typeLabel =
+            item.type === 'credit-card' ? '信用卡' : item.type === 'huabei' ? '花呗' : '贷款';
+          const annualRate = item.type === 'loan' ? `，年化利率 ${item.annualRate || 0}%` : '';
+          const months = item.type === 'loan' ? `，剩余期数 ${item.remainingMonths || 12}` : '';
+          return `${item.name}（${typeLabel}）：本金 ¥${item.balance.toFixed(2)}，最低还款 ¥${minimum.toFixed(2)}${annualRate}${months}`;
+        })
+        .join('\n');
+
+      const result = await sendAiChat({
+        baseUrl,
+        apiKey,
+        model,
+        systemPrompt:
+          '你是资深个人财务顾问，请用简体中文给出可执行的还款管理建议。优先考虑现金流安全、降低利息、避免逾期，并给出分步骤计划。',
+        messages: [
+          {
+            role: 'user',
+            text: `请基于以下负债情况给我一个未来 3 个月还款方案，并输出：\n1) 优先级排序\n2) 每月执行动作\n3) 风险提醒\n\n月收入：¥${monthlyIncome.toFixed(2)}\n总负债：¥${debtSummary.totalDebt.toFixed(2)}\n每月最低还款：¥${debtSummary.totalMinimumPayment.toFixed(2)}\n负债压力：${(debtSummary.pressureRatio * 100).toFixed(1)}%\n\n负债列表：\n${debtLines}`
+          }
+        ]
+      });
+
+      setRepaymentAdvice(result.content);
+      setRepaymentReasoning(result.reasoning || '');
+    } catch (err) {
+      setError((err as Error).message || 'AI 还款建议生成失败，请检查模型配置。');
+    } finally {
+      setRepaymentLoading(false);
+    }
+  }
+
   return (
-    <div className="page-stack">
+    <div className="page-stack finance-page">
       <section id="debt-management" className="card">
         <h2 style={{ marginTop: 0 }}>💳 负债管理</h2>
         <p className="muted">支持信用卡、花呗、贷款，自动计算每月最低还款额与总负债压力。</p>
@@ -260,10 +312,7 @@ export function FinancePage() {
           </label>
         </div>
 
-        <form
-          onSubmit={onAddDebt}
-          style={{ display: 'grid', gap: 8, gridTemplateColumns: '1.4fr 1fr 1fr 1fr 1fr auto' }}
-        >
+        <form onSubmit={onAddDebt} className="finance-debt-form-grid">
           <input
             value={debtName}
             onChange={(event) => setDebtName(event.target.value)}
@@ -354,6 +403,29 @@ export function FinancePage() {
             {monthlyIncome <= 0 ? '（请填写月收入）' : ''}
           </p>
         </div>
+
+        <div className="card" style={{ marginTop: 12, padding: 12 }}>
+          <h3 style={{ marginTop: 0 }}>🤖 AI 还款策略</h3>
+          <p className="muted" style={{ marginTop: 0 }}>
+            结合当前负债与月收入，生成未来 3 个月分步还款建议。
+          </p>
+          <button type="button" onClick={onGenerateRepaymentAdvice} disabled={repaymentLoading}>
+            {repaymentLoading ? '生成中...' : '生成 AI 还款建议'}
+          </button>
+          {repaymentAdvice ? (
+            <pre className="finance-ai-result">{repaymentAdvice}</pre>
+          ) : (
+            <p className="muted" style={{ marginBottom: 0 }}>
+              暂无建议，点击上方按钮即可生成。
+            </p>
+          )}
+          {repaymentReasoning ? (
+            <details style={{ marginTop: 10 }}>
+              <summary style={{ cursor: 'pointer' }}>查看模型思考摘要</summary>
+              <pre className="finance-ai-result">{repaymentReasoning}</pre>
+            </details>
+          ) : null}
+        </div>
       </section>
 
       <section className="card">
@@ -366,15 +438,7 @@ export function FinancePage() {
           </summary>
 
           <div style={{ marginTop: 10, display: 'grid', gap: 8 }}>
-            <form
-              onSubmit={onAddFeed}
-              style={{
-                display: 'grid',
-                gap: 8,
-                gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1.4fr) auto',
-                alignItems: 'center'
-              }}
-            >
+            <form onSubmit={onAddFeed} className="finance-feed-form-grid">
               <input
                 value={feedTitle}
                 onChange={(event) => setFeedTitle(event.target.value)}


### PR DESCRIPTION
### Motivation
- 解决 Finance 页面中“负债管理”与“金融资讯”区块在部分屏幕/布局下出现内容挤压、重叠的问题以提升可用性和可读性。 
- 为用户提供基于当前负债与收入的可执行还款策略，通过大模型辅助生成分步建议以提升还款决策效率。

### Description
- 增加通用布局与卡片样式：在 `src/app/styles/global.css` 中新增 `.page-stack` 与 `.card`，并新增响应式表单栅格样式 `finance-debt-form-grid`、`finance-feed-form-grid` 与 AI 输出样式 `finance-ai-result`，并加入媒体查询避免中小屏挤压。 
- 更新 `FinancePage`（`src/pages/finance/FinancePage.tsx`）将原行内表单样式替换为栅格类名并调整顶级容器为 `page-stack finance-page`，以消除区块重叠。 
- 接入 AI 还款建议：引入 `useAiSettings` 读取 `baseUrl`/`apiKey`/`model` 并使用现有 `sendAiChat`（OpenAI 兼容客户端）实现 `onGenerateRepaymentAdvice`，基于 `monthlyIncome`、`debtSummary` 与各笔 `debts` 生成未来 3 个月的还款方案并展示模型返回的内容与可选 reasoning。 
- 增加 UI：在“负债管理”下新增“🤖 AI 还款策略”卡片，包含触发按钮、加载态与文本输出区域，且在订阅管理表单使用新栅格以避免拥挤。

### Testing
- 运行 `npm run lint`（含 pre-commit 格式化与修复任务）并通过。 
- 运行 `npm run build`（TypeScript 检查 + `vite build`）并通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991bf12c2b88331bd91cd21b2060c22)