### PR TITLE
feat(exchange): support draggable split ratio and align card spacing

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -4070,7 +4070,59 @@ small.mono {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: var(--space-3);
+}
+
+.exchange-card-header {
   margin-bottom: var(--space-4);
+}
+
+.exchange-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, var(--exchange-left-width, 420px)) 12px minmax(0, 1fr);
+  align-items: stretch;
+  column-gap: var(--space-3);
+}
+
+.exchange-data-card {
+  min-width: 0;
+}
+
+.exchange-data-header {
+  display: flex;
+  align-items: center;
+}
+
+.exchange-resize-divider {
+  width: 12px;
+  cursor: col-resize;
+  border-radius: var(--radius-sm);
+  align-self: stretch;
+  background: linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 4px,
+    var(--color-border) 4px,
+    var(--color-border) 8px,
+    transparent 8px,
+    transparent 100%
+  );
+}
+
+.exchange-resize-divider:hover {
+  background: linear-gradient(
+    90deg,
+    transparent 0,
+    transparent 4px,
+    var(--color-primary) 4px,
+    var(--color-primary) 8px,
+    transparent 8px,
+    transparent 100%
+  );
+}
+
+body.exchange-resizing {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .exchange-base-picker {
@@ -5110,6 +5162,15 @@ small.mono {
 }
 
 @media (max-width: 640px) {
+  .exchange-layout {
+    grid-template-columns: 1fr;
+    row-gap: var(--space-3);
+  }
+
+  .exchange-resize-divider {
+    display: none;
+  }
+
   .exchange-converter-row {
     flex-direction: column;
     align-items: stretch;

--- a/src/features/exchange/ui/ExchangePage.tsx
+++ b/src/features/exchange/ui/ExchangePage.tsx
@@ -1,3 +1,10 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent
+} from 'react';
 import { useExchangeRates } from '../hooks/useExchangeRates';
 import { ExchangeRateTable } from './ExchangeRateTable';
 import { ExchangeConverter } from './ExchangeConverter';
@@ -6,17 +13,73 @@ import { getCurrencyFlag, getCurrencyName, CURRENCY_NAMES } from '../model/types
 /** 基准货币候选列表 */
 const BASE_OPTIONS = ['CNY', 'USD', 'EUR', 'GBP', 'JPY', 'HKD', 'SGD', 'AUD', 'CAD', 'CHF'];
 
+const MIN_LEFT_WIDTH = 320;
+const MIN_RIGHT_WIDTH = 420;
+const DEFAULT_LEFT_WIDTH = 420;
+
 export function ExchangePage() {
   const { rates, base, date, loading, error, fromCache, setBase, refresh } =
     useExchangeRates('CNY');
+  const layoutRef = useRef<HTMLDivElement | null>(null);
+  const [leftWidth, setLeftWidth] = useState(DEFAULT_LEFT_WIDTH);
 
   /** 所有可用货币代码（用于基准切换下拉） */
   const allCodes = Object.keys(CURRENCY_NAMES).sort();
 
+  useEffect(() => {
+    const clampByContainer = () => {
+      const node = layoutRef.current;
+      if (!node) {
+        return;
+      }
+
+      const total = node.getBoundingClientRect().width;
+      const maxLeft = Math.max(MIN_LEFT_WIDTH, total - MIN_RIGHT_WIDTH);
+      setLeftWidth((prev) => Math.min(Math.max(prev, MIN_LEFT_WIDTH), maxLeft));
+    };
+
+    clampByContainer();
+    window.addEventListener('resize', clampByContainer);
+
+    return () => {
+      window.removeEventListener('resize', clampByContainer);
+    };
+  }, []);
+
+  const handleDividerMouseDown = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const container = layoutRef.current;
+    if (!container) {
+      return;
+    }
+
+    const rect = container.getBoundingClientRect();
+    const maxLeft = Math.max(MIN_LEFT_WIDTH, rect.width - MIN_RIGHT_WIDTH);
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const nextWidth = Math.min(Math.max(moveEvent.clientX - rect.left, MIN_LEFT_WIDTH), maxLeft);
+      setLeftWidth(nextWidth);
+    };
+
+    const onMouseUp = () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+      document.body.classList.remove('exchange-resizing');
+    };
+
+    document.body.classList.add('exchange-resizing');
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  };
+
   return (
-    <div>
+    <div
+      className="exchange-layout"
+      ref={layoutRef}
+      style={{ '--exchange-left-width': `${leftWidth}px` } as CSSProperties}
+    >
       <section className="panel exchange-priority-converter">
-        <div className="exchange-header">
+        <div className="exchange-header exchange-card-header">
           <h2 style={{ margin: 0 }}>💱 汇率换算器</h2>
           <div className="exchange-base-picker">
             <label htmlFor="exchange-base-code">基准货币：</label>
@@ -51,19 +114,27 @@ export function ExchangePage() {
         <ExchangeConverter rates={rates} base={base} />
       </section>
 
-      <section className="panel" style={{ marginTop: 12 }}>
-        <details className="exchange-rates-collapse">
-          <summary>汇率数据（点击展开）</summary>
-          <ExchangeRateTable
-            rates={rates}
-            base={base}
-            date={date}
-            fromCache={fromCache}
-            loading={loading}
-            error={error}
-            onRefresh={refresh}
-          />
-        </details>
+      <div
+        className="exchange-resize-divider"
+        role="separator"
+        aria-label="调整汇率换算器与汇率数据宽度"
+        aria-orientation="vertical"
+        onMouseDown={handleDividerMouseDown}
+      />
+
+      <section className="panel exchange-data-card">
+        <div className="exchange-data-header exchange-card-header">
+          <h2 style={{ margin: 0 }}>📊 汇率数据</h2>
+        </div>
+        <ExchangeRateTable
+          rates={rates}
+          base={base}
+          date={date}
+          fromCache={fromCache}
+          loading={loading}
+          error={error}
+          onRefresh={refresh}
+        />
       </section>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Provide a better desktop UX by allowing users to adjust the width ratio between the exchange converter and rate list via mouse drag. 
- Prevent layout breakage by enforcing minimum widths for both cards and clamping sizes on container resize. 
- Keep UI consistent by unifying header spacing for both cards and preserving mobile single-column behavior.

### Description
- Added a draggable vertical divider and resize logic in `ExchangePage` with bounded widths (`MIN_LEFT_WIDTH`, `MIN_RIGHT_WIDTH`) and window resize clamping, and exported as a CSS custom property `--exchange-left-width` (`src/features/exchange/ui/ExchangePage.tsx`).
- Imported `CSSProperties` and aliased `MouseEvent` to `ReactMouseEvent` to type the inline style and divider mouse handler (`src/features/exchange/ui/ExchangePage.tsx`).
- Converted the layout to a 3-column grid (left pane, 12px divider, right pane) and added divider styles, hover state, and `body.exchange-resizing` cursor/user-select behavior; unified card header spacing with `.exchange-card-header` and hid the divider under 640px (`src/app/styles/global.css`).
- Replaced the previous collapsed-rate UI with the inline right-side rate card so the split/resizing behavior applies on desktop while preserving the single-column mobile fallback.

### Testing
- Ran lint with `npm run lint` which completed successfully. 
- Executed unit tests with `npm run test -- src/features/exchange/ui/ExchangeConverter.test.tsx src/features/exchange/ui/ExchangeRateTable.test.tsx` and all tests passed (2 files, 6 tests). 
- Attempted a Playwright-based visual check, but the headless Chromium process crashed in this environment (SIGSEGV) so an automated screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699273829fa48331b136dd6790a58fb7)