### PR TITLE
fix: add Settings to '杂项' sidebar and restrict topbar logo/menu to collapsed state

### DIFF
--- a/src/widgets/layout/AppLayout.tsx
+++ b/src/widgets/layout/AppLayout.tsx
@@ -44,6 +44,7 @@ const navSections: Array<{ title: string; items: NavItem[] }> = [
   {
     title: '杂项',
     items: [
+      { to: '/settings', label: '设置', icon: '⚙️' },
       { to: '/exchange', label: '汇率数据', icon: '💱' },
       { to: '/finance', label: '金融资讯', icon: '📰' },
       { to: '/about', label: '关于', icon: 'ℹ️' }
@@ -160,6 +161,12 @@ export function AppLayout() {
   }, []);
 
   useEffect(() => {
+    if (!collapsed && menuOpen) {
+      setMenuOpen(false);
+    }
+  }, [collapsed, menuOpen]);
+
+  useEffect(() => {
     if (mobileNavOpen) {
       document.body.style.overflow = 'hidden';
     } else {
@@ -256,35 +263,39 @@ export function AppLayout() {
             >
               ☰
             </button>
-            <button
-              type="button"
-              className="logo-circle"
-              onClick={() => setMenuOpen((v) => !v)}
-              aria-haspopup="menu"
-              aria-expanded={menuOpen}
-              aria-label="打开项目菜单"
-            >
-              👤
-            </button>
-            {menuOpen ? (
-              <div className="logo-menu" role="menu">
-                {logoMenuItems.map((item) => (
-                  <Link
-                    key={item.to}
-                    to={item.to}
-                    className="logo-menu-item"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <span className="logo-menu-icon">{item.icon}</span> {item.label}
-                  </Link>
-                ))}
-              </div>
-            ) : null}
+            {collapsed ? (
+              <>
+                <button
+                  type="button"
+                  className="logo-circle"
+                  onClick={() => setMenuOpen((v) => !v)}
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                  aria-label="打开项目菜单"
+                >
+                  👤
+                </button>
+                {menuOpen ? (
+                  <div className="logo-menu" role="menu">
+                    {logoMenuItems.map((item) => (
+                      <Link
+                        key={item.to}
+                        to={item.to}
+                        className="logo-menu-item"
+                        onClick={() => setMenuOpen(false)}
+                      >
+                        <span className="logo-menu-icon">{item.icon}</span> {item.label}
+                      </Link>
+                    ))}
+                  </div>
+                ) : null}
 
-            <div className={`topbar-brand-copy ${collapsed ? 'compact' : ''}`.trim()}>
-              <h1>LedgerFlow</h1>
-              <span>智能记账工作台</span>
-            </div>
+                <div className="topbar-brand-copy compact">
+                  <h1>LedgerFlow</h1>
+                  <span>智能记账工作台</span>
+                </div>
+              </>
+            ) : null}
           </div>
         </header>
 


### PR DESCRIPTION
### Motivation
- Ensure `设置` is discoverable from the main navigation by placing it under the sidebar `杂项` section so it remains accessible when the topbar profile menu is hidden. 
- Avoid duplicate branding in the topbar and keep menu state consistent when the sidebar expands.

### Description
- Added a dedicated `设置` nav item to the `杂项` section in `src/widgets/layout/AppLayout.tsx` so `设置` appears in the main sidebar. 
- Render the topbar profile button, dropdown menu and compact brand copy only when `collapsed` is `true`, and remove duplicate brand rendering in the expanded layout. 
- Added a `useEffect` hook to automatically call `setMenuOpen(false)` when the sidebar becomes expanded to ensure the menu closes.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Started the dev server with `npm run dev` and captured a Playwright screenshot to visually verify the sidebar now shows `设置` under `杂项`. 
- Pre-commit tasks (`prettier` and `eslint --fix`) ran during the commit process and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6992740198a48331a402f4dcaf7e4c3a)