### PR TITLE
feat(transactions): support filtering uncategorized transactions

### DIFF
--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { TransactionItem } from '../../../entities/transaction/types';
+import { EMPTY_CATEGORY_FILTER_VALUE } from '../model/categoryQuickFilter';
 import { formatCurrency, formatDate } from '../../../shared/lib/format';
 import { EmptyState } from '../../../shared/ui/EmptyState';
 import { TableSkeleton } from '../../../shared/ui/TableSkeleton';
@@ -490,6 +491,7 @@ export function TransactionTable({
                             }
                           >
                             <option value="">全部分类</option>
+                            <option value={EMPTY_CATEGORY_FILTER_VALUE}>未分类</option>
                             {categoryOptions.map((option) => (
                               <option key={option.id} value={option.id}>
                                 {option.name}

--- a/src/features/transactions/model/categoryQuickFilter.test.ts
+++ b/src/features/transactions/model/categoryQuickFilter.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { EMPTY_CATEGORY_FILTER_VALUE, matchesCategoryQuickFilter } from './categoryQuickFilter';
+
+describe('matchesCategoryQuickFilter', () => {
+  it('returns true for all categories when filter is empty', () => {
+    expect(matchesCategoryQuickFilter('', 'cat-1')).toBe(true);
+    expect(matchesCategoryQuickFilter('', '')).toBe(true);
+  });
+
+  it('matches specific category id', () => {
+    expect(matchesCategoryQuickFilter('cat-1', 'cat-1')).toBe(true);
+    expect(matchesCategoryQuickFilter('cat-1', 'cat-2')).toBe(false);
+  });
+
+  it('matches uncategorized transactions when empty-category filter is selected', () => {
+    expect(matchesCategoryQuickFilter(EMPTY_CATEGORY_FILTER_VALUE, '')).toBe(true);
+    expect(matchesCategoryQuickFilter(EMPTY_CATEGORY_FILTER_VALUE, '   ')).toBe(true);
+    expect(matchesCategoryQuickFilter(EMPTY_CATEGORY_FILTER_VALUE, 'cat-1')).toBe(false);
+  });
+});

--- a/src/features/transactions/model/categoryQuickFilter.ts
+++ b/src/features/transactions/model/categoryQuickFilter.ts
@@ -1,0 +1,15 @@
+export const EMPTY_CATEGORY_FILTER_VALUE = '__empty_category__';
+
+export function matchesCategoryQuickFilter(categoryFilter: string, categoryId: string): boolean {
+  const normalizedCategoryId = categoryId.trim();
+
+  if (!categoryFilter) {
+    return true;
+  }
+
+  if (categoryFilter === EMPTY_CATEGORY_FILTER_VALUE) {
+    return normalizedCategoryId.length === 0;
+  }
+
+  return normalizedCategoryId === categoryFilter;
+}

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -26,6 +26,7 @@ import {
   TransactionSortKey,
   TransactionTable
 } from '../../features/transactions/components/TransactionTable';
+import { matchesCategoryQuickFilter } from '../../features/transactions/model/categoryQuickFilter';
 import {
   resolveDateRange,
   useTransactionFilters
@@ -510,7 +511,7 @@ export function TransactionsPage() {
     return mappedRows.filter((row) => {
       const dateText = formatDate(row.item.date).toLowerCase();
       const typePass = quickFilters.type === 'all' ? true : row.item.type === quickFilters.type;
-      const categoryPass = !categoryFilter || row.item.categoryId === categoryFilter;
+      const categoryPass = matchesCategoryQuickFilter(categoryFilter, row.item.categoryId);
       const accountPass = !accountFilter || row.accountName.toLowerCase().includes(accountFilter);
       const orderNoPass =
         !orderNoFilter || (row.item.orderNo || '').toLowerCase().includes(orderNoFilter);


### PR DESCRIPTION
### Motivation
- 支持在交易列表的分类快速筛选中选取“未分类”（即 categoryId 为空或仅包含空白字符）的记录，解决分类筛选无法匹配空分类的问题。

### Description
- 新增 `src/features/transactions/model/categoryQuickFilter.ts`，提供 `EMPTY_CATEGORY_FILTER_VALUE` 常量与 `matchesCategoryQuickFilter` 函数用于统一判断分类筛选匹配逻辑。 
- 在 `src/features/transactions/components/TransactionTable.tsx` 的分类下拉中添加“未分类”选项并引用上述常量。 
- 将 `src/pages/transactions/TransactionsPage.tsx` 中的分类匹配逻辑替换为 `matchesCategoryQuickFilter`，以正确匹配空字符串或空白的 `categoryId`。 
- 新增单元测试 `src/features/transactions/model/categoryQuickFilter.test.ts`，覆盖全部/指定分类/未分类三种场景。

### Testing
- 运行单测 `npm test -- --run src/features/transactions/model/categoryQuickFilter.test.ts`，测试通过。 
- 运行构建 `npm run build` 成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6992770f0e24833186c08a31d44792ab)