### PR TITLE
fix: restore assistant preset cache helpers

### DIFF
--- a/src/pages/assistant/AssistantPage.tsx
+++ b/src/pages/assistant/AssistantPage.tsx
@@ -243,6 +243,61 @@ interface PresetQuestionsCachePayload {
   questions: CachedPresetQuestion[];
 }
 
+function withPresetIds(questions: CachedPresetQuestion[], namespace: string): PresetQuestion[] {
+  return questions.map((item, index) => ({
+    id: `${namespace}-${index}`,
+    label: item.label,
+    prompt: item.prompt
+  }));
+}
+
+function buildPresetQuestionsSignature(transactions: TransactionItem[], categories: Category[]) {
+  const txSignature = transactions
+    .slice(-120)
+    .map((item) => `${item.date}|${item.type}|${item.amount}|${item.categoryId}|${item.note ?? ''}`)
+    .join('~');
+  const categorySignature = categories
+    .map((item) => `${item.id}:${item.name}`)
+    .sort()
+    .join('~');
+  return `${transactions.length}:${categories.length}:${categorySignature}:${txSignature}`;
+}
+
+function readPresetQuestionsCache(signature: string): CachedPresetQuestion[] | null {
+  try {
+    const raw = window.localStorage.getItem(PRESET_QUESTIONS_CACHE_KEY);
+    if (!raw) return null;
+    const payload = JSON.parse(raw) as PresetQuestionsCachePayload;
+    if (
+      !payload ||
+      payload.signature !== signature ||
+      Date.now() - payload.updatedAt > PRESET_QUESTIONS_CACHE_TTL_MS ||
+      !Array.isArray(payload.questions)
+    ) {
+      return null;
+    }
+    return payload.questions.filter(
+      (item): item is CachedPresetQuestion =>
+        Boolean(item) && typeof item.label === 'string' && typeof item.prompt === 'string'
+    );
+  } catch {
+    return null;
+  }
+}
+
+function writePresetQuestionsCache(signature: string, questions: CachedPresetQuestion[]) {
+  try {
+    const payload: PresetQuestionsCachePayload = {
+      signature,
+      updatedAt: Date.now(),
+      questions
+    };
+    window.localStorage.setItem(PRESET_QUESTIONS_CACHE_KEY, JSON.stringify(payload));
+  } catch {
+    // ignore storage write errors
+  }
+}
+
 function readChatHistory(mode: AssistantMode): ChatHistoryItem[] {
   try {
     const raw = window.sessionStorage.getItem(CHAT_HISTORY_CACHE_KEYS[mode]);


### PR DESCRIPTION
### Motivation

- 修复 Assistant 页面在构建时缺失的预设问题缓存辅助函数导致的 TypeScript 错误并恢复个性化预设加载逻辑。 
- 增加缓存签名与 TTL 校验以避免因过期或脏数据触发不一致的预设行为。 

### Description

- 在 `src/pages/assistant/AssistantPage.tsx` 中新增并恢复了四个辅助函数：`withPresetIds`、`buildPresetQuestionsSignature`、`readPresetQuestionsCache` 和 `writePresetQuestionsCache`。 
- `buildPresetQuestionsSignature` 基于最近交易（最多 120 条）和分类生成确定性签名用于缓存一致性校验。 
- `readPresetQuestionsCache`/`writePresetQuestionsCache` 使用 `window.localStorage` 存取并对载荷结构与 TTL (`PRESET_QUESTIONS_CACHE_TTL_MS`) 进行校验与过滤以保证安全性。 
- `withPresetIds` 将缓存项映射为带 `id` 的 `PresetQuestion` 以恢复现有的预设展示/区分逻辑。 

### Testing

- 运行 `npm run build`（即 `tsc --noEmit && vite build`）成功完成并生成 `dist`，构建通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69927865df14833188706c780843913f)