### PR TITLE
feat(transactions): constrain date pickers to available bill dates

### DIFF
--- a/src/features/transactions/components/TransactionFilters.test.tsx
+++ b/src/features/transactions/components/TransactionFilters.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { TransactionFilters } from './TransactionFilters';
+
+describe('TransactionFilters', () => {
+  it('在自定义日期模式下为日期输入设置可用区间', () => {
+    render(
+      <MemoryRouter>
+        <TransactionFilters
+          filters={{
+            keyword: '',
+            type: 'all',
+            source: 'all',
+            datePreset: 'custom',
+            dateFrom: '',
+            dateTo: '',
+            page: 1
+          }}
+          onKeywordChange={() => undefined}
+          onTypeChange={() => undefined}
+          onSourceChange={() => undefined}
+          onDatePresetChange={() => undefined}
+          onDateFromChange={() => undefined}
+          onDateToChange={() => undefined}
+          onClear={() => undefined}
+          onExport={() => undefined}
+          onImportWechat={() => undefined}
+          onImportAlipay={() => undefined}
+          importMode="incremental"
+          onImportModeChange={() => undefined}
+          onCheckDuplicates={() => undefined}
+          columnOptions={[{ key: 'date', label: '日期' }]}
+          visibleColumns={{
+            date: true,
+            type: true,
+            category: true,
+            account: true,
+            amount: true,
+            orderNo: true,
+            merchantOrderNo: true,
+            note: true
+          }}
+          onToggleColumn={vi.fn()}
+          bulkSelectionEnabled={false}
+          onToggleBulkSelection={() => undefined}
+          minAvailableDate="2026-02-01"
+          maxAvailableDate="2026-02-28"
+        />
+      </MemoryRouter>
+    );
+
+    const fromInput = screen.getByLabelText('筛选开始日期');
+    const toInput = screen.getByLabelText('筛选结束日期');
+
+    expect(fromInput).toHaveAttribute('min', '2026-02-01');
+    expect(fromInput).toHaveAttribute('max', '2026-02-28');
+    expect(toInput).toHaveAttribute('min', '2026-02-01');
+    expect(toInput).toHaveAttribute('max', '2026-02-28');
+  });
+});

--- a/src/features/transactions/components/TransactionFilters.tsx
+++ b/src/features/transactions/components/TransactionFilters.tsx
@@ -29,6 +29,8 @@ interface TransactionFiltersProps {
   onToggleColumn: (key: TransactionColumnKey) => void;
   bulkSelectionEnabled: boolean;
   onToggleBulkSelection: () => void;
+  minAvailableDate?: string;
+  maxAvailableDate?: string;
 }
 
 export function TransactionFilters({
@@ -50,7 +52,9 @@ export function TransactionFilters({
   visibleColumns,
   onToggleColumn,
   bulkSelectionEnabled,
-  onToggleBulkSelection
+  onToggleBulkSelection,
+  minAvailableDate,
+  maxAvailableDate
 }: TransactionFiltersProps) {
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -116,6 +120,8 @@ export function TransactionFilters({
               id="tx-filter-date-from"
               aria-label="筛选开始日期"
               type="date"
+              min={minAvailableDate}
+              max={maxAvailableDate}
               onFocus={(event) => event.currentTarget.showPicker?.()}
               value={filters.dateFrom}
               onChange={(event) => onDateFromChange(event.target.value)}
@@ -140,6 +146,8 @@ export function TransactionFilters({
               id="tx-filter-date-to"
               aria-label="筛选结束日期"
               type="date"
+              min={minAvailableDate}
+              max={maxAvailableDate}
               onFocus={(event) => event.currentTarget.showPicker?.()}
               value={filters.dateTo}
               onChange={(event) => onDateToChange(event.target.value)}

--- a/src/features/transactions/components/TransactionTable.test.tsx
+++ b/src/features/transactions/components/TransactionTable.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TransactionTable } from './TransactionTable';
+
+describe('TransactionTable', () => {
+  it('日期快捷筛选输入应用可用日期范围', () => {
+    render(
+      <TransactionTable
+        rows={[]}
+        total={0}
+        filteredTotal={0}
+        page={1}
+        pages={1}
+        pageSize={8}
+        pageSizeOptions={[8, 20]}
+        loading={false}
+        hasFilters
+        selectedIds={[]}
+        bulkSelectionEnabled={false}
+        canSelectAllOnPage={false}
+        allPageSelected={false}
+        sortKey="date"
+        sortDirection="desc"
+        quickFilters={{
+          date: '',
+          type: 'all',
+          category: '',
+          account: '',
+          amountMin: '',
+          amountMax: '',
+          tags: '',
+          merchant: '',
+          orderNo: '',
+          merchantOrderNo: '',
+          note: ''
+        }}
+        onRetry={vi.fn()}
+        onClearFilters={vi.fn()}
+        onPrevPage={vi.fn()}
+        onNextPage={vi.fn()}
+        onPageSizeChange={vi.fn()}
+        onOpenDetail={vi.fn()}
+        onDelete={vi.fn()}
+        onDeleteSelected={vi.fn()}
+        onBulkEditCategory={vi.fn()}
+        onBulkAiRecategorize={vi.fn()}
+        onBulkEditAccount={vi.fn()}
+        categoryOptions={[]}
+        accountOptions={[]}
+        onClearSelection={vi.fn()}
+        onToggleSelect={vi.fn()}
+        onToggleSelectPage={vi.fn()}
+        onSortChange={vi.fn()}
+        onQuickFilterChange={vi.fn()}
+        visibleColumns={{
+          date: true,
+          type: true,
+          category: true,
+          account: true,
+          amount: true,
+          orderNo: true,
+          merchantOrderNo: true,
+          note: true
+        }}
+        columnOrder={[
+          'date',
+          'type',
+          'category',
+          'account',
+          'amount',
+          'orderNo',
+          'merchantOrderNo',
+          'note'
+        ]}
+        onColumnReorder={vi.fn()}
+        columnWidths={{}}
+        onColumnResize={vi.fn()}
+        minAvailableDate="2026-02-01"
+        maxAvailableDate="2026-02-28"
+      />
+    );
+
+    const dateInput = screen.getByPlaceholderText('筛选日期');
+    expect(dateInput).toHaveAttribute('min', '2026-02-01');
+    expect(dateInput).toHaveAttribute('max', '2026-02-28');
+  });
+});

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -113,6 +113,8 @@ interface TransactionTableProps {
   onColumnReorder: (fromKey: TransactionColumnKey, toKey: TransactionColumnKey) => void;
   columnWidths: Partial<Record<TransactionColumnKey, number>>;
   onColumnResize: (key: TransactionColumnKey, width: number) => void;
+  minAvailableDate?: string;
+  maxAvailableDate?: string;
 }
 
 export function TransactionTable({
@@ -156,7 +158,9 @@ export function TransactionTable({
   columnOrder,
   onColumnReorder,
   columnWidths,
-  onColumnResize
+  onColumnResize,
+  minAvailableDate,
+  maxAvailableDate
 }: TransactionTableProps) {
   const [swipedId, setSwipedId] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; id: string } | null>(null);
@@ -483,6 +487,8 @@ export function TransactionTable({
                         {column.key === 'date' ? (
                           <input
                             type="date"
+                            min={minAvailableDate}
+                            max={maxAvailableDate}
                             value={quickFilters.date}
                             onChange={(event) => onQuickFilterChange('date', event.target.value)}
                             placeholder="筛选日期"

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -1060,6 +1060,24 @@ export function TransactionsPage() {
     ? detectSource(selected.source, selected.note, selected.tags)
     : 'manual';
 
+  const availableDateBounds = useMemo(() => {
+    let min = '';
+    let max = '';
+    transactions.forEach((item) => {
+      const day = String(item.date || '').slice(0, 10);
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+        return;
+      }
+      if (!min || day < min) {
+        min = day;
+      }
+      if (!max || day > max) {
+        max = day;
+      }
+    });
+    return { min, max };
+  }, [transactions]);
+
   return (
     <div className="transactions-page">
       <TransactionFilters
@@ -1082,6 +1100,8 @@ export function TransactionsPage() {
         onToggleColumn={handleToggleColumn}
         bulkSelectionEnabled={bulkSelectionEnabled}
         onToggleBulkSelection={() => setBulkSelectionEnabled((prev) => !prev)}
+        minAvailableDate={availableDateBounds.min}
+        maxAvailableDate={availableDateBounds.max}
       />
 
       {importNotice.visible ? (
@@ -1155,6 +1175,8 @@ export function TransactionsPage() {
         onColumnReorder={handleColumnReorder}
         columnWidths={columnWidths}
         onColumnResize={handleColumnResize}
+        minAvailableDate={availableDateBounds.min}
+        maxAvailableDate={availableDateBounds.max}
       />
 
       <TransactionDetailDrawer


### PR DESCRIPTION
### Motivation
- 防止用户在账单详情/筛选中选择或跳转到没有数据的日期区间，改进日历交互（不可选日期应为灰色/不可点击）。
- 通过限制原生日期输入的 `min`/`max` 属性，让浏览器日历本地展示禁用与配色差异，提升可用性与可感知性。

### Description
- 在 `TransactionsPage` 中新增 `availableDateBounds` 计算逻辑，从现有交易中提取最早/最晚 `YYYY-MM-DD` 日期并以 `{min,max}` 暴露。  
- 为 `TransactionFilters` 添加 `minAvailableDate` / `maxAvailableDate` 参数并将其绑定到自定义筛选的 `开始日期` / `结束日期` 输入的 `min`/`max` 属性。  
- 为 `TransactionTable` 添加同样的 `minAvailableDate` / `maxAvailableDate` 参数并将其绑定到表头的日期快捷筛选输入的 `min`/`max` 属性。  
- 新增组件单元测试 `TransactionFilters.test.tsx` 与 `TransactionTable.test.tsx` 用于断言日期输入已正确接收 `min`/`max` 属性。

### Testing
- 运行组件测试：`npm test -- src/features/transactions/components/TransactionFilters.test.tsx src/features/transactions/components/TransactionTable.test.tsx`，两项测试均通过。  
- 运行静态检查：`npm run lint`，检查通过（无警告/错误）。  
- 使用 Playwright 自动化验证页面渲染：Chromium 启动时出现容器内崩溃导致失败，但改为使用 Firefox 成功截取页面以辅助人工核验（用于可视化验证）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69927f2aac0083318c7dc3f1611a15c7)