### PR TITLE
优化还款管理页层级并将负债总览升级为数据卡片

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -6099,6 +6099,75 @@ body.exchange-resizing {
   align-content: start;
 }
 
+.finance-primary-panel {
+  border-color: color-mix(in srgb, var(--color-primary) 42%, var(--color-border));
+  box-shadow: 0 10px 20px color-mix(in srgb, var(--color-primary) 16%, transparent);
+}
+
+.finance-secondary-panel {
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, var(--color-bg-subtle));
+}
+
+.finance-overview-panel {
+  background: color-mix(in srgb, var(--color-bg-elevated) 78%, var(--color-primary-soft));
+}
+
+.finance-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.finance-overview-metric-card {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  padding: 10px;
+  background: var(--color-bg-elevated);
+}
+
+.finance-overview-label {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-sm);
+}
+
+.finance-overview-value {
+  margin: 8px 0 0;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.finance-overview-number {
+  font-size: clamp(1.25rem, 2vw, 1.7rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.finance-overview-unit {
+  font-size: var(--font-sm);
+  color: var(--color-text-muted);
+}
+
+.finance-overview-pressure-card {
+  border-width: 2px;
+}
+
+.finance-overview-pressure-safe {
+  border-color: color-mix(in srgb, var(--color-success) 70%, var(--color-border));
+  background: color-mix(in srgb, var(--color-success-soft) 55%, var(--color-bg-elevated));
+}
+
+.finance-overview-pressure-warning {
+  border-color: color-mix(in srgb, var(--color-warning) 72%, var(--color-border));
+  background: color-mix(in srgb, var(--color-warning-soft) 58%, var(--color-bg-elevated));
+}
+
+.finance-overview-pressure-danger {
+  border-color: color-mix(in srgb, var(--color-danger) 70%, var(--color-border));
+  background: color-mix(in srgb, var(--color-danger-soft) 58%, var(--color-bg-elevated));
+}
+
 .finance-debt-form-grid {
   display: grid;
   gap: 8px;
@@ -6126,11 +6195,19 @@ body.exchange-resizing {
   .finance-debt-form-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+
+  .finance-overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 760px) {
   .finance-debt-form-grid,
   .finance-feed-form-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .finance-overview-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/src/pages/repayment-management/RepaymentManagementPage.tsx
+++ b/src/pages/repayment-management/RepaymentManagementPage.tsx
@@ -204,6 +204,19 @@ function parseIncomeExtraction(content: string): { monthlyIncome?: number; reaso
   };
 }
 
+function getPressureLevel(ratio: number): {
+  tone: 'safe' | 'warning' | 'danger';
+  label: string;
+} {
+  if (ratio < 0.3) {
+    return { tone: 'safe', label: '健康' };
+  }
+  if (ratio < 0.6) {
+    return { tone: 'warning', label: '关注' };
+  }
+  return { tone: 'danger', label: '偏高' };
+}
+
 export function RepaymentManagementPage() {
   const { debts, monthlyIncome, setMonthlyIncome, addDebt, replaceDebts, removeDebt } =
     useAppPreferences();
@@ -228,6 +241,10 @@ export function RepaymentManagementPage() {
   const debtSummary = useMemo(
     () => calculateDebtSummary(debts, monthlyIncome),
     [debts, monthlyIncome]
+  );
+  const pressureLevel = useMemo(
+    () => getPressureLevel(debtSummary.pressureRatio),
+    [debtSummary.pressureRatio]
   );
 
   const incomeSamples = useMemo(
@@ -559,47 +576,53 @@ export function RepaymentManagementPage() {
           ) : null}
         </div>
 
-        <form onSubmit={onAddDebt} className="finance-debt-form-grid">
-          <input
-            value={debtName}
-            onChange={(event) => setDebtName(event.target.value)}
-            placeholder="负债名称"
-          />
-          <select
-            value={debtType}
-            onChange={(event) => setDebtType(event.target.value as DebtType)}
-          >
-            <option value="credit-card">信用卡</option>
-            <option value="consumer-loan">消费贷</option>
-            <option value="loan">贷款</option>
-          </select>
-          <input
-            type="number"
-            min={0}
-            step="0.01"
-            value={debtBalance}
-            onChange={(event) => setDebtBalance(event.target.value)}
-            placeholder="剩余本金"
-          />
-          <input
-            type="number"
-            min={0}
-            step="0.01"
-            value={debtAnnualRate}
-            onChange={(event) => setDebtAnnualRate(event.target.value)}
-            placeholder="年化利率%"
-            disabled={debtType !== 'loan'}
-          />
-          <input
-            type="number"
-            min={1}
-            value={debtMonths}
-            onChange={(event) => setDebtMonths(event.target.value)}
-            placeholder="剩余期数"
-            disabled={debtType !== 'loan'}
-          />
-          <button type="submit">新增</button>
-        </form>
+        <div className="card finance-secondary-panel" style={{ marginBottom: 12, padding: 12 }}>
+          <h3 style={{ marginTop: 0 }}>✍️ 手动填写负债</h3>
+          <p className="muted" style={{ margin: '0 0 8px 0' }}>
+            用于补充识别失败或新增账单，贷款支持年化利率与期数输入。
+          </p>
+          <form onSubmit={onAddDebt} className="finance-debt-form-grid">
+            <input
+              value={debtName}
+              onChange={(event) => setDebtName(event.target.value)}
+              placeholder="负债名称"
+            />
+            <select
+              value={debtType}
+              onChange={(event) => setDebtType(event.target.value as DebtType)}
+            >
+              <option value="credit-card">信用卡</option>
+              <option value="consumer-loan">消费贷</option>
+              <option value="loan">贷款</option>
+            </select>
+            <input
+              type="number"
+              min={0}
+              step="0.01"
+              value={debtBalance}
+              onChange={(event) => setDebtBalance(event.target.value)}
+              placeholder="剩余本金"
+            />
+            <input
+              type="number"
+              min={0}
+              step="0.01"
+              value={debtAnnualRate}
+              onChange={(event) => setDebtAnnualRate(event.target.value)}
+              placeholder="年化利率%"
+              disabled={debtType !== 'loan'}
+            />
+            <input
+              type="number"
+              min={1}
+              value={debtMonths}
+              onChange={(event) => setDebtMonths(event.target.value)}
+              placeholder="剩余期数"
+              disabled={debtType !== 'loan'}
+            />
+            <button type="submit">新增</button>
+          </form>
+        </div>
 
         <div style={{ marginTop: 12, display: 'grid', gap: 8 }}>
           {debts.length === 0 ? <p className="muted">还没有负债记录，先新增一条吧。</p> : null}
@@ -639,19 +662,45 @@ export function RepaymentManagementPage() {
           })}
         </div>
 
-        <div className="card" style={{ marginTop: 12, padding: 12 }}>
-          <h3 style={{ marginTop: 0 }}>负债压力总览</h3>
-          <p style={{ margin: '4px 0' }}>总负债：¥{debtSummary.totalDebt.toFixed(2)}</p>
-          <p style={{ margin: '4px 0' }}>
-            每月最低还款：¥{debtSummary.totalMinimumPayment.toFixed(2)}
-          </p>
-          <p style={{ margin: '4px 0' }}>
-            负债压力：{(debtSummary.pressureRatio * 100).toFixed(1)}%
-            {monthlyIncome <= 0 ? '（待 AI 从账单详情估算月收入）' : ''}
-          </p>
+        <div className="card finance-overview-panel" style={{ marginTop: 12, padding: 12 }}>
+          <h3 style={{ marginTop: 0 }}>📊 负债压力总览</h3>
+          <div className="finance-overview-grid">
+            <article className="finance-overview-metric-card">
+              <p className="finance-overview-label">总负债</p>
+              <p className="finance-overview-value">
+                <span className="finance-overview-number">{debtSummary.totalDebt.toFixed(2)}</span>
+                <span className="finance-overview-unit">¥</span>
+              </p>
+            </article>
+            <article className="finance-overview-metric-card">
+              <p className="finance-overview-label">每月最低还款</p>
+              <p className="finance-overview-value">
+                <span className="finance-overview-number">
+                  {debtSummary.totalMinimumPayment.toFixed(2)}
+                </span>
+                <span className="finance-overview-unit">¥</span>
+              </p>
+            </article>
+            <article
+              className={`finance-overview-metric-card finance-overview-pressure-card finance-overview-pressure-${pressureLevel.tone}`}
+            >
+              <p className="finance-overview-label">负债率（{pressureLevel.label}）</p>
+              <p className="finance-overview-value">
+                <span className="finance-overview-number">
+                  {(debtSummary.pressureRatio * 100).toFixed(1)}
+                </span>
+                <span className="finance-overview-unit">%</span>
+              </p>
+            </article>
+          </div>
+          {monthlyIncome <= 0 ? (
+            <p className="muted" style={{ margin: '8px 0 0' }}>
+              负债率待 AI 从账单详情估算月收入后会更准确。
+            </p>
+          ) : null}
         </div>
 
-        <div className="card" style={{ marginTop: 12, padding: 12 }}>
+        <div className="card finance-primary-panel" style={{ marginTop: 12, padding: 12 }}>
           <h3 style={{ marginTop: 0 }}>🤖 AI 还款策略</h3>
           <p className="muted" style={{ marginTop: 0 }}>
             结合当前负债与 AI 估算月收入，生成未来 3 个月分步还款建议。


### PR DESCRIPTION
### Motivation
- 解决页面各功能模块（上传截图、手动填写、负债总览、AI 策略）视觉权重接近、主次不明显的问题。 
- 增强“负债压力总览”的视觉冲击，提升页面的“财务感”与数据可读性。 

### Description
- 将原有手动填写表单从平铺形式移入独立次级面板（新增 `.finance-secondary-panel`），并补充了标题与说明文案以降低平铺感。 
- 把“AI 还款策略”提升为主操作面板（新增 `.finance-primary-panel`），增加主色边框与阴影以突出核心操作区。 
- 将“负债压力总览”从简单文本块改为横向 3 个数据卡片（总负债 / 每月最低还款 / 负债率），数字加粗放大、单位缩小展示，并根据负债率区间通过 `getPressureLevel` 以三色（绿/黄/红）高亮。 
- 新增响应式样式与类名（`.finance-overview-panel`, `.finance-overview-grid`, `.finance-overview-metric-card`, 相关 `.finance-overview-pressure-*`），在中小屏下分别降级为 2 列或 1 列展示。 

### Testing
- 运行 `npm run build`（包含 `tsc --noEmit` 与 Vite 构建）通过并成功生成产物。 
- 本地启动开发服务器并可访问页面（`npm run dev -- --host 0.0.0.0 --port 4173`），启动成功用于可视化验证。 
- 使用 Playwright 脚本打开 `/repayment-management` 并生成全页截图以检查 UI 效果，脚本执行并产出截图，视觉验证通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69927ff327ac8331aae7009c6d91263a)