### PR TITLE
优化还款管理页添加负债表单布局与按钮样式

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -6170,8 +6170,26 @@ body.exchange-resizing {
 
 .finance-debt-form-grid {
   display: grid;
-  gap: 8px;
-  grid-template-columns: minmax(0, 1.4fr) repeat(4, minmax(0, 1fr)) auto;
+  gap: 18px;
+}
+
+.finance-debt-form-row {
+  display: grid;
+  gap: 10px;
+  align-items: center;
+}
+
+.finance-debt-form-row-primary {
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+}
+
+.finance-debt-form-row-detail {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.finance-debt-form-actions {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .finance-feed-form-grid {
@@ -6192,17 +6210,14 @@ body.exchange-resizing {
 }
 
 @media (max-width: 1120px) {
-  .finance-debt-form-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
   .finance-overview-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 760px) {
-  .finance-debt-form-grid,
+  .finance-debt-form-row-primary,
+  .finance-debt-form-row-detail,
   .finance-feed-form-grid {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/src/pages/repayment-management/RepaymentManagementPage.tsx
+++ b/src/pages/repayment-management/RepaymentManagementPage.tsx
@@ -576,51 +576,59 @@ export function RepaymentManagementPage() {
           ) : null}
         </div>
 
-        <div className="card finance-secondary-panel" style={{ marginBottom: 12, padding: 12 }}>
+        <div className="card finance-secondary-panel" style={{ marginBottom: 12, padding: 24 }}>
           <h3 style={{ marginTop: 0 }}>✍️ 手动填写负债</h3>
           <p className="muted" style={{ margin: '0 0 8px 0' }}>
             用于补充识别失败或新增账单，贷款支持年化利率与期数输入。
           </p>
           <form onSubmit={onAddDebt} className="finance-debt-form-grid">
-            <input
-              value={debtName}
-              onChange={(event) => setDebtName(event.target.value)}
-              placeholder="负债名称"
-            />
-            <select
-              value={debtType}
-              onChange={(event) => setDebtType(event.target.value as DebtType)}
-            >
-              <option value="credit-card">信用卡</option>
-              <option value="consumer-loan">消费贷</option>
-              <option value="loan">贷款</option>
-            </select>
-            <input
-              type="number"
-              min={0}
-              step="0.01"
-              value={debtBalance}
-              onChange={(event) => setDebtBalance(event.target.value)}
-              placeholder="剩余本金"
-            />
-            <input
-              type="number"
-              min={0}
-              step="0.01"
-              value={debtAnnualRate}
-              onChange={(event) => setDebtAnnualRate(event.target.value)}
-              placeholder="年化利率%"
-              disabled={debtType !== 'loan'}
-            />
-            <input
-              type="number"
-              min={1}
-              value={debtMonths}
-              onChange={(event) => setDebtMonths(event.target.value)}
-              placeholder="剩余期数"
-              disabled={debtType !== 'loan'}
-            />
-            <button type="submit">新增</button>
+            <div className="finance-debt-form-row finance-debt-form-row-primary">
+              <input
+                value={debtName}
+                onChange={(event) => setDebtName(event.target.value)}
+                placeholder="负债名称"
+              />
+              <select
+                value={debtType}
+                onChange={(event) => setDebtType(event.target.value as DebtType)}
+              >
+                <option value="credit-card">信用卡</option>
+                <option value="consumer-loan">消费贷</option>
+                <option value="loan">贷款</option>
+              </select>
+            </div>
+            <div className="finance-debt-form-row finance-debt-form-row-detail">
+              <input
+                type="number"
+                min={0}
+                step="0.01"
+                value={debtBalance}
+                onChange={(event) => setDebtBalance(event.target.value)}
+                placeholder="剩余本金"
+              />
+              <input
+                type="number"
+                min={0}
+                step="0.01"
+                value={debtAnnualRate}
+                onChange={(event) => setDebtAnnualRate(event.target.value)}
+                placeholder="年化利率%"
+                disabled={debtType !== 'loan'}
+              />
+              <input
+                type="number"
+                min={1}
+                value={debtMonths}
+                onChange={(event) => setDebtMonths(event.target.value)}
+                placeholder="剩余期数"
+                disabled={debtType !== 'loan'}
+              />
+            </div>
+            <div className="finance-debt-form-actions">
+              <button type="submit" className="primary">
+                + 添加负债
+              </button>
+            </div>
           </form>
         </div>
 


### PR DESCRIPTION
### Motivation
- 修复“添加负债”表单所有输入横向拥挤的问题，改善视觉层次并提升移动端可用性。 
- 将表单按语义分组，使字段更易扫描并保持界面简洁。 
- 保持现有功能不变，仅调整布局与样式以提升可读性。 

### Description
- 重构表单 DOM 结构为三行：第一行为 `负债名称`（宽度偏大）与 `类型`，第二行为 `剩余本金`、`年化利率%`、`剩余期数` 三等分，第三行为独立操作区包含主按钮，按钮文本改为 `+ 添加负债` 并使用 `primary` 样式（修改文件 `src/pages/repayment-management/RepaymentManagementPage.tsx`）。
- 将表单卡片内边距由 `12px` 调整为 `24px`，并在表单行间增加 `18px` 间距（修改文件 `src/app/styles/global.css`）。
- 新增样式类：`.finance-debt-form-row`、`.finance-debt-form-row-primary`（60/40 比例）、`.finance-debt-form-row-detail`（三列等宽）与 `.finance-debt-form-actions`（右对齐），并保留移动端单列折叠规则以确保响应式表现。 
- 未改变任何业务逻辑，只调整布局与按钮样式，保持行为与表单提交逻辑不变。 

### Testing
- 运行 `npm run lint`，检查并修复了样式/代码风格问题，执行成功。 
- 运行 `npm run build` 进行类型检查与打包，构建成功且生成产物。 
- 已在本地启动开发服务器并查看页面以确认响应式折叠（仅作为人工验证，自动测试为上述命令）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6992828186d08331bf9e6006dc9f257c)