### PR TITLE
fix: prevent duplicate bulk AI recategorize clicks

### DIFF
--- a/src/features/transactions/components/TransactionTable.test.tsx
+++ b/src/features/transactions/components/TransactionTable.test.tsx
@@ -44,6 +44,7 @@ describe('TransactionTable', () => {
         onDeleteSelected={vi.fn()}
         onBulkEditCategory={vi.fn()}
         onBulkAiRecategorize={vi.fn()}
+        bulkAiRecategorizing={false}
         onBulkEditAccount={vi.fn()}
         categoryOptions={[]}
         accountOptions={[]}
@@ -83,5 +84,100 @@ describe('TransactionTable', () => {
     const dateInput = screen.getByPlaceholderText('筛选日期');
     expect(dateInput).toHaveAttribute('min', '2026-02-01');
     expect(dateInput).toHaveAttribute('max', '2026-02-28');
+  });
+
+  it('批量 AI 重分类进行中时按钮禁用并展示进行状态', () => {
+    render(
+      <TransactionTable
+        rows={[
+          {
+            item: {
+              id: 'tx-1',
+              date: '2026-02-10',
+              type: 'expense',
+              categoryId: 'cat-1',
+              accountId: 'acc-1',
+              amount: 88,
+              note: '测试',
+              tags: []
+            },
+            categoryName: '餐饮',
+            accountName: '现金'
+          }
+        ]}
+        total={1}
+        filteredTotal={1}
+        page={1}
+        pages={1}
+        pageSize={8}
+        pageSizeOptions={[8, 20]}
+        loading={false}
+        hasFilters
+        selectedIds={['tx-1']}
+        bulkSelectionEnabled
+        canSelectAllOnPage
+        allPageSelected
+        sortKey="date"
+        sortDirection="desc"
+        quickFilters={{
+          date: '',
+          type: 'all',
+          category: '',
+          account: '',
+          amountMin: '',
+          amountMax: '',
+          tags: '',
+          merchant: '',
+          orderNo: '',
+          merchantOrderNo: '',
+          note: ''
+        }}
+        onRetry={vi.fn()}
+        onClearFilters={vi.fn()}
+        onPrevPage={vi.fn()}
+        onNextPage={vi.fn()}
+        onPageSizeChange={vi.fn()}
+        onOpenDetail={vi.fn()}
+        onDelete={vi.fn()}
+        onDeleteSelected={vi.fn()}
+        onBulkEditCategory={vi.fn()}
+        onBulkAiRecategorize={vi.fn()}
+        bulkAiRecategorizing
+        onBulkEditAccount={vi.fn()}
+        categoryOptions={[]}
+        accountOptions={[]}
+        onClearSelection={vi.fn()}
+        onToggleSelect={vi.fn()}
+        onToggleSelectPage={vi.fn()}
+        onSortChange={vi.fn()}
+        onQuickFilterChange={vi.fn()}
+        visibleColumns={{
+          date: true,
+          type: true,
+          category: true,
+          account: true,
+          amount: true,
+          orderNo: true,
+          merchantOrderNo: true,
+          note: true
+        }}
+        columnOrder={[
+          'date',
+          'type',
+          'category',
+          'account',
+          'amount',
+          'orderNo',
+          'merchantOrderNo',
+          'note'
+        ]}
+        onColumnReorder={vi.fn()}
+        columnWidths={{}}
+        onColumnResize={vi.fn()}
+      />
+    );
+
+    const aiButton = screen.getByRole('button', { name: '🤖 AI 重分类中…' });
+    expect(aiButton).toBeDisabled();
   });
 });

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -97,6 +97,7 @@ interface TransactionTableProps {
   onDeleteSelected: () => void;
   onBulkEditCategory: (categoryId: string) => void;
   onBulkAiRecategorize: () => void;
+  bulkAiRecategorizing: boolean;
   onBulkEditAccount: (accountId: string) => void;
   categoryOptions: Array<{ id: string; name: string }>;
   accountOptions: Array<{ id: string; name: string }>;
@@ -146,6 +147,7 @@ export function TransactionTable({
   onDeleteSelected,
   onBulkEditCategory,
   onBulkAiRecategorize,
+  bulkAiRecategorizing,
   onBulkEditAccount,
   categoryOptions,
   accountOptions,
@@ -349,8 +351,12 @@ export function TransactionTable({
                     ))}
                   </select>
                 </label>
-                <button type="button" onClick={onBulkAiRecategorize}>
-                  🤖 AI 重分类
+                <button
+                  type="button"
+                  onClick={onBulkAiRecategorize}
+                  disabled={bulkAiRecategorizing}
+                >
+                  {bulkAiRecategorizing ? '🤖 AI 重分类中…' : '🤖 AI 重分类'}
                 </button>
                 <label className="transaction-bulk-select">
                   <span>批量账户</span>

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -358,6 +358,7 @@ export function TransactionsPage() {
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const importSourceRef = useRef<BillSource | null>(null);
+  const bulkAiRecategorizingRef = useRef(false);
 
   const dateRange = useMemo(() => resolveDateRange(filters), [filters]);
 
@@ -882,34 +883,39 @@ export function TransactionsPage() {
   };
 
   const handleBulkAiRecategorize = async () => {
-    if (selectedIds.length === 0 || bulkAiRecategorizing) {
+    if (selectedIds.length === 0 || bulkAiRecategorizingRef.current) {
       return;
     }
 
+    bulkAiRecategorizingRef.current = true;
     setBulkAiRecategorizing(true);
     let changed = 0;
     let fallbackChanged = 0;
 
-    for (const id of selectedIds) {
-      const tx = transactions.find((item) => item.id === id);
-      if (!tx) continue;
-      const result = await recategorizeByAi(tx);
-      if (result === 'changed') {
-        changed += 1;
+    try {
+      for (const id of selectedIds) {
+        const tx = transactions.find((item) => item.id === id);
+        if (!tx) continue;
+        const result = await recategorizeByAi(tx);
+        if (result === 'changed') {
+          changed += 1;
+        }
+        if (result === 'fallback-changed') {
+          fallbackChanged += 1;
+        }
       }
-      if (result === 'fallback-changed') {
-        fallbackChanged += 1;
-      }
-    }
 
-    if (changed > 0) {
-      showToast(`已按大模型建议完成 ${changed} 条交易重分类。`, 'success');
-    } else if (fallbackChanged > 0) {
-      showToast(`已按账单信息完成 ${fallbackChanged} 条交易重分类。`, 'success');
-    } else {
-      showToast('AI 分类建议未变化，无需替换。', 'warning');
+      if (changed > 0) {
+        showToast(`已按大模型建议完成 ${changed} 条交易重分类。`, 'success');
+      } else if (fallbackChanged > 0) {
+        showToast(`已按账单信息完成 ${fallbackChanged} 条交易重分类。`, 'success');
+      } else {
+        showToast('AI 分类建议未变化，无需替换。', 'warning');
+      }
+    } finally {
+      bulkAiRecategorizingRef.current = false;
+      setBulkAiRecategorizing(false);
     }
-    setBulkAiRecategorizing(false);
   };
 
   const hasQuickFilters =
@@ -1164,6 +1170,7 @@ export function TransactionsPage() {
         onDeleteSelected={handleDeleteSelected}
         onBulkEditCategory={handleBulkEditCategory}
         onBulkAiRecategorize={() => void handleBulkAiRecategorize()}
+        bulkAiRecategorizing={bulkAiRecategorizing}
         onBulkEditAccount={handleBulkEditAccount}
         categoryOptions={categories.map((item) => ({ id: item.id, name: item.name }))}
         accountOptions={accounts.map((item) => ({ id: item.id, name: item.name }))}


### PR DESCRIPTION
### Motivation
- 避免在批量 AI 重分类操作中用户重复点击触发多次并发执行，需在 UI 上展示“进行中”状态并禁止重复点击以保证幂等性与体验。

### Description
- 在 `TransactionsPage` 中添加 `bulkAiRecategorizingRef`（`useRef`）作为同步锁，防止短时间内重复触发 `handleBulkAiRecategorize`，并在 `finally` 中释放锁以确保状态可恢复。（`src/pages/transactions/TransactionsPage.tsx`）
- 将 `bulkAiRecategorizing` 状态透传到 `TransactionTable`，并在表格组件中新增该 prop 到 `TransactionTableProps`。（`src/features/transactions/components/TransactionTable.tsx`）
- 在批量操作栏中将“🤖 AI 重分类”按钮在进行中时禁用并切换为文案 `🤖 AI 重分类中…`，从而提供明确的进行态与防连点交互。（`src/features/transactions/components/TransactionTable.tsx`）
- 补充/更新单元测试以覆盖按钮在进行中时被禁用并显示进行状态的场景，同时修正测试用例中交易项字段（`tags`）以匹配类型声明。（`src/features/transactions/components/TransactionTable.test.tsx`）

### Testing
- 运行单元测试 `npm run test -- src/features/transactions/components/TransactionTable.test.tsx`，所有测试通过（1 测试文件，2 个测试均通过）。
- 提交时触发的预提交任务（`prettier`、`eslint` 等）已运行且通过。 
- 使用本地 dev server + Playwright 脚本做了自动化交互检查并截取 UI 状态截图以验证按钮行为，脚本执行成功并生成截图。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699284575dd483319df5b6b0f60c866f)