### PR TITLE
优化统计分析页结构并重构未来趋势图展示

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -1680,8 +1680,8 @@ small.mono {
 
 .dashboard-summary-main-amount {
   display: inline;
-  font-size: clamp(26px, 5.2vw, 34px);
-  line-height: 1.15;
+  font-size: clamp(30px, 6.2vw, 42px);
+  line-height: 1.1;
   letter-spacing: 0.01em;
   font-weight: 800;
   color: var(--color-text);
@@ -1695,13 +1695,29 @@ small.mono {
   color: var(--color-expense);
 }
 
-.dashboard-summary-sub {
-  margin: 8px 0 0 0;
-  font-size: var(--font-sm);
-  display: flex;
+.dashboard-summary-change {
+  margin: 6px 0 0;
+  display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 4px 8px;
+  gap: 8px;
+  font-size: var(--font-sm);
+  font-weight: 600;
+}
+
+.dashboard-summary-change.positive {
+  color: var(--color-income);
+}
+
+.dashboard-summary-change.negative {
+  color: var(--color-expense);
+}
+
+.dashboard-summary-sub {
+  margin: 10px 0 0 0;
+  font-size: var(--font-sm);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
 }
 
 .dashboard-summary-metric {
@@ -1719,10 +1735,6 @@ small.mono {
 
 .dashboard-summary-metric.neutral {
   color: var(--color-text-secondary);
-}
-
-.dashboard-summary-dot {
-  color: var(--color-text-placeholder);
 }
 
 .dashboard-summary-chip {
@@ -1832,8 +1844,14 @@ small.mono {
 
 .dashboard-ai-actions {
   margin-top: var(--space-2);
-  display: flex;
-  justify-content: flex-end;
+  display: grid;
+  gap: 6px;
+}
+
+.dashboard-ai-status-text {
+  margin: 0;
+  font-size: var(--font-xs);
+  color: var(--color-text-secondary);
 }
 
 .dashboard-ai-error {
@@ -2094,12 +2112,6 @@ small.mono {
   border-color: var(--color-border);
 }
 
-.dashboard-forecast-key span.current {
-  color: var(--color-primary);
-  border-color: var(--color-primary-border);
-  background: color-mix(in srgb, var(--color-primary) 16%, transparent);
-}
-
 .dashboard-forecast-key span.forecast {
   color: #b26a00;
   border-color: #f1c052;
@@ -2124,12 +2136,6 @@ small.mono {
   color: var(--color-text-secondary);
 }
 
-.dashboard-forecast-legend span.current {
-  color: var(--color-primary);
-  border-color: var(--color-primary-border);
-  background: color-mix(in srgb, var(--color-primary) 12%, transparent);
-}
-
 .dashboard-forecast-legend span.forecast {
   color: #b26a00;
   border-color: #f1c052;
@@ -2138,10 +2144,6 @@ small.mono {
 
 .dashboard-forecast-chart .history-line {
   stroke: #b4b7bd;
-}
-
-.dashboard-forecast-chart .current-line {
-  stroke: var(--color-primary);
 }
 
 .dashboard-forecast-chart .forecast-line {
@@ -2168,6 +2170,12 @@ small.mono {
 .dashboard-forecast-point:hover circle {
   transform: scale(1.18);
   fill: color-mix(in srgb, var(--color-primary) 22%, var(--color-bg-elevated));
+}
+
+.dashboard-forecast-hover {
+  margin: 8px 0 0;
+  font-size: var(--font-xs);
+  color: var(--color-text-secondary);
 }
 
 .dashboard-future-focus-item {
@@ -2264,7 +2272,7 @@ small.mono {
   }
 
   .dashboard-ai-actions {
-    justify-content: flex-start;
+    gap: 4px;
   }
 
   .dashboard-trend-summary {
@@ -2280,11 +2288,8 @@ small.mono {
   }
 
   .dashboard-summary-sub {
-    gap: 2px 6px;
-  }
-
-  .dashboard-summary-dot {
-    display: inline;
+    grid-template-columns: 1fr;
+    gap: 6px;
   }
 
   .dashboard-section-header {
@@ -5439,16 +5444,41 @@ body.exchange-resizing {
 }
 
 .dashboard-forecast-quick-cards {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
   margin-top: 12px;
 }
+
 .dashboard-forecast-quick-card {
   border: 1px solid var(--color-border-light);
   border-radius: 10px;
-  padding: 10px;
+  padding: 12px;
   background: var(--color-bg-subtle);
+}
+
+.dashboard-forecast-quick-card > p {
+  margin: 0 0 10px;
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+}
+
+.dashboard-forecast-quick-values {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.dashboard-forecast-quick-value-item {
+  display: grid;
+  gap: 4px;
+}
+
+.dashboard-forecast-quick-value-item span {
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+}
+
+.dashboard-forecast-quick-value-item strong {
+  font-size: var(--font-sm);
+  color: var(--color-text);
 }
 
 .about-page {

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -164,7 +164,10 @@ export function DashboardPage() {
   >('idle');
   const [monthlyInsightError, setMonthlyInsightError] = useState('');
   const [monthlyInsightRequestToken, setMonthlyInsightRequestToken] = useState(0);
-  const [monthlyInsightProgress, setMonthlyInsightProgress] = useState(0);
+  const [hoveredChartPoint, setHoveredChartPoint] = useState<{
+    label: string;
+    value: number;
+  } | null>(null);
 
   const now = new Date();
   const currentMonth = now.getMonth();
@@ -434,23 +437,6 @@ export function DashboardPage() {
   }, [aiInput, apiKey, baseUrl, forecastRequestToken, model, monthlyBalance, transactions.length]);
 
   useEffect(() => {
-    if (monthlyInsightStatus !== 'loading' && monthlyInsightStatus !== 'streaming') {
-      setMonthlyInsightProgress(monthlyInsightStatus === 'done' ? 100 : 0);
-      return;
-    }
-
-    setMonthlyInsightProgress((prev) => (prev > 8 ? prev : 8));
-    const timer = window.setInterval(() => {
-      setMonthlyInsightProgress((prev) => {
-        const cap = monthlyInsightStatus === 'streaming' ? 94 : 86;
-        return Math.min(cap, prev + Math.max(1, Math.round((100 - prev) * 0.08)));
-      });
-    }, 380);
-
-    return () => window.clearInterval(timer);
-  }, [monthlyInsightStatus]);
-
-  useEffect(() => {
     if (transactions.length === 0) return;
     if (monthlyInsightRequestToken <= 0) return;
 
@@ -509,11 +495,9 @@ export function DashboardPage() {
           highlights
         };
         setMonthlyInsight(next);
-        setMonthlyInsightProgress(100);
         setMonthlyInsightStatus('done');
       } catch (error) {
         if (!canceled) {
-          setMonthlyInsightProgress(0);
           setMonthlyInsightStatus('error');
           setMonthlyInsightError(error instanceof Error ? error.message : '本月趋势分析失败');
         }
@@ -542,10 +526,11 @@ export function DashboardPage() {
     setMonthlyInsightRequestToken((prev) => prev + 1);
   };
 
-  const currentIndex = Math.max(recentMonths.length - 1, 0);
+  const reducedHistoryMonths = useMemo(() => recentMonths.slice(-4), [recentMonths]);
+  const currentIndex = Math.max(reducedHistoryMonths.length - 1, 0);
 
   const chartData = useMemo(() => {
-    const history = recentMonths.map((item) => ({
+    const history = reducedHistoryMonths.map((item) => ({
       label: item.shortLabel,
       value: item.balance,
       type: 'history' as const
@@ -559,7 +544,7 @@ export function DashboardPage() {
       };
     });
     return [...history, ...future];
-  }, [currentMonth, currentYear, forecast?.points, monthlyBalance, recentMonths]);
+  }, [currentMonth, currentYear, forecast?.points, monthlyBalance, reducedHistoryMonths]);
 
   const chartRange = useMemo(() => {
     const values = chartData.map((item) => item.value);
@@ -588,18 +573,38 @@ export function DashboardPage() {
 
   const historySegment = useMemo(() => {
     if (chartPoints.length < 2 || currentIndex < 1) return '';
-    return buildSmoothPath(chartPoints.slice(0, currentIndex));
-  }, [chartPoints, currentIndex]);
-
-  const currentSegment = useMemo(() => {
-    if (chartPoints.length < 2 || currentIndex < 1) return '';
-    return buildSmoothPath(chartPoints.slice(currentIndex - 1, currentIndex + 1));
+    return buildSmoothPath(chartPoints.slice(0, currentIndex + 1));
   }, [chartPoints, currentIndex]);
 
   const forecastSegment = useMemo(() => {
     if (chartPoints.length - currentIndex < 2) return '';
     return buildSmoothPath(chartPoints.slice(currentIndex, chartPoints.length));
   }, [chartPoints, currentIndex]);
+
+  const lastMonthBalance = recentMonths[recentMonths.length - 2]?.balance ?? 0;
+  const monthOverMonthChange = monthlyBalance - lastMonthBalance;
+  const monthOverMonthRate =
+    lastMonthBalance === 0
+      ? monthOverMonthChange === 0
+        ? 0
+        : 100
+      : (monthOverMonthChange / Math.abs(lastMonthBalance)) * 100;
+  const monthOverMonthDirection = monthOverMonthChange >= 0 ? 'up' : 'down';
+  const monthOverMonthArrow = monthOverMonthChange >= 0 ? '↗' : '↘';
+  const forecastMonths = useMemo(() => {
+    const values = forecast?.points?.slice(0, 3) || [
+      monthlyBalance,
+      monthlyBalance * 0.98,
+      monthlyBalance * 0.96
+    ];
+    return values.map((value, index) => {
+      const d = new Date(currentYear, currentMonth + index + 1, 1);
+      return {
+        label: monthLabel(d),
+        value: toSafeNumber(value, monthlyBalance)
+      };
+    });
+  }, [currentMonth, currentYear, forecast?.points, monthlyBalance]);
 
   const currentMonthLabel = `${currentYear}年${currentMonth + 1}月`;
   const monthlyInsightActionLabel =
@@ -902,53 +907,41 @@ export function DashboardPage() {
                     {formatCurrency(monthlyBalance)}
                   </span>
                 </p>
+                <p
+                  className={`dashboard-summary-change ${
+                    monthOverMonthDirection === 'up' ? 'positive' : 'negative'
+                  }`}
+                >
+                  <span>{monthOverMonthArrow}</span>
+                  <span>环比 {Math.abs(monthOverMonthRate).toFixed(1)}%</span>
+                  <span>
+                    ({monthOverMonthChange >= 0 ? '+' : ''}
+                    {formatCurrency(monthOverMonthChange)})
+                  </span>
+                </p>
                 <p className="dashboard-summary-sub">
                   <span className="dashboard-summary-metric income">
                     收入 {formatCurrency(income)}
                   </span>
-                  <span className="dashboard-summary-dot">·</span>
                   <span className="dashboard-summary-metric expense">
                     支出 {formatCurrency(expense)}
                   </span>
-                  <span className="dashboard-summary-dot">·</span>
                   <span className="dashboard-summary-metric neutral">交易 {monthly.length} 笔</span>
                 </p>
               </div>
               <div className="dashboard-summary-chip">AI 分析聚焦于本月分类结构与异常波动</div>
             </div>
 
-            <div className="dashboard-insight-progress" aria-live="polite">
-              <div className="dashboard-insight-progress-head">
-                <span>AI 洞察进度</span>
-                <strong>{monthlyInsightProgress}%</strong>
-              </div>
-              <div className="dashboard-insight-progress-track">
-                <span style={{ width: `${monthlyInsightProgress}%` }} />
-              </div>
-              <p>
+            <div className="dashboard-ai-actions" style={{ marginBottom: 'var(--space-3)' }}>
+              <p className="dashboard-ai-status-text">
                 {monthlyInsightStatus === 'loading'
                   ? '正在整理本月账目结构…'
                   : monthlyInsightStatus === 'streaming'
                     ? '正在生成重点结论，请稍候。'
                     : monthlyInsightStatus === 'done'
                       ? '分析完成，可查看分类与重点账目。'
-                      : '点击“重新分析”开始生成。'}
+                      : '点击右上角“重新分析”开始生成。'}
               </p>
-            </div>
-
-            <div className="dashboard-ai-actions" style={{ marginBottom: 'var(--space-3)' }}>
-              <button
-                type="button"
-                className="dashboard-forecast-refresh"
-                onClick={handleRefreshMonthlyInsight}
-                disabled={
-                  monthlyInsightStatus === 'loading' ||
-                  monthlyInsightStatus === 'streaming' ||
-                  transactions.length === 0
-                }
-              >
-                重新分析
-              </button>
               {monthlyInsightError ? (
                 <p className="dashboard-ai-error">{monthlyInsightError}</p>
               ) : null}
@@ -1027,7 +1020,11 @@ export function DashboardPage() {
             </div>
             {forecastError ? <p className="dashboard-future-tip">{forecastError}</p> : null}
 
-            <div className="dashboard-forecast-chart" aria-label="未来趋势动态图表">
+            <div
+              className="dashboard-forecast-chart"
+              aria-label="未来趋势动态图表"
+              onMouseLeave={() => setHoveredChartPoint(null)}
+            >
               <div className="dashboard-forecast-axes">
                 <div className="dashboard-forecast-axis-y" aria-label="金额轴">
                   {axisTicks.map((value, index) => (
@@ -1061,16 +1058,6 @@ export function DashboardPage() {
                       strokeLinejoin="round"
                     />
                   ) : null}
-                  {currentSegment ? (
-                    <path
-                      d={currentSegment}
-                      className="current-line dashboard-forecast-path"
-                      fill="none"
-                      strokeWidth="3.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  ) : null}
                   {forecastSegment ? (
                     <path
                       d={forecastSegment}
@@ -1083,7 +1070,17 @@ export function DashboardPage() {
                   ) : null}
                   {chartPoints.map((point, index) => (
                     <g key={`point-${point.label}-${index}`} className="dashboard-forecast-point">
-                      <circle cx={point.x} cy={point.y} r={index === currentIndex ? 4.8 : 3.6} />
+                      <circle
+                        cx={point.x}
+                        cy={point.y}
+                        r={index === currentIndex ? 4.8 : 3.6}
+                        onMouseEnter={() =>
+                          setHoveredChartPoint({
+                            label: point.label,
+                            value: point.value
+                          })
+                        }
+                      />
                       <title>{`${point.label}：${formatCurrency(point.value)}`}</title>
                     </g>
                   ))}
@@ -1106,17 +1103,16 @@ export function DashboardPage() {
               </div>
               <div className="dashboard-forecast-key" aria-label="趋势颜色说明">
                 <span className="history">历史</span>
-                <span className="current">当前</span>
-                <span className="forecast">未来</span>
+                <span className="forecast">预测</span>
               </div>
+              <p className="dashboard-forecast-hover">
+                {hoveredChartPoint
+                  ? `${hoveredChartPoint.label}：${formatCurrency(hoveredChartPoint.value)}`
+                  : '悬停数据点查看具体数值'}
+              </p>
               <div className="dashboard-forecast-legend">
                 {chartData.map((item, index) => {
-                  const klass =
-                    index === currentIndex
-                      ? 'current'
-                      : item.type === 'forecast'
-                        ? 'forecast'
-                        : 'history';
+                  const klass = item.type === 'forecast' ? 'forecast' : 'history';
                   const prefix = item.type === 'forecast' ? '预测' : '';
                   return (
                     <span key={`${item.label}-${index}`} className={klass}>
@@ -1129,15 +1125,17 @@ export function DashboardPage() {
             </div>
 
             <div className="dashboard-forecast-quick-cards">
-              {chartData.slice(currentIndex).map((item, index) => (
-                <article
-                  key={`future-card-${item.label}-${index}`}
-                  className="dashboard-forecast-quick-card"
-                >
-                  <p>{index === 0 ? '本月基线' : `未来第${index}个月`}</p>
-                  <strong>{formatCurrency(item.value)}</strong>
-                </article>
-              ))}
+              <article className="dashboard-forecast-quick-card">
+                <p>未来3个月预测</p>
+                <div className="dashboard-forecast-quick-values">
+                  {forecastMonths.map((item) => (
+                    <div key={item.label} className="dashboard-forecast-quick-value-item">
+                      <span>{item.label}</span>
+                      <strong>{formatCurrency(item.value)}</strong>
+                    </div>
+                  ))}
+                </div>
+              </article>
             </div>
 
             <p className="dashboard-future-text">


### PR DESCRIPTION
### Motivation
- 提升仪表盘中“本月核心数据”的可读性与权重，简洁化 AI 洞察交互，并把未来趋势展示调整为更专业的历史/预测视图。

### Description
- 在 `DashboardPage` 中将“本月结余”字体放大并在下方新增环比变化（箭头 + 百分比 + 差值），同时将收入/支出/交易笔数改为横向三列排列以突出核心数据；移除原 AI 进度条，仅保留简洁状态文案并把“重新分析”入口保留为卡片右上角操作按钮（文件：`src/pages/dashboard/DashboardPage.tsx`）。
- 将趋势图历史段点位数量缩减（最近 4 个月）、历史线以实线渲染、预测段以虚线渲染，并把图例精简为“历史 / 预测”；去除中间的“当前”样式以简化视觉层级（文件：`src/pages/dashboard/DashboardPage.tsx` 和 `src/app/styles/global.css`）。
- 增强图表交互：数据点 hover 时在图表下方显示月份与具体金额的文案提示；将底部原先的多张预测小卡片合并为单个“未来3个月预测”卡片并横向展示三个月数值（文件：`src/pages/dashboard/DashboardPage.tsx` 和 `src/app/styles/global.css`）。
- 同步调整样式以符合“简洁理财产品风格”，包括数值放大、色彩与间距优化（文件：`src/app/styles/global.css`）。

### Testing
- 运行 `npm run lint`：通过（无 lint 错误）。
- 运行 `npm run test -- src/pages/dashboard/DashboardPage.test.tsx`：通过（相关单元测试已通过）。
- 运行 `npm run build`：构建成功（生产包生成无报错）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6992a2ac1bc48331a22c3f4002f1e49d)