### PR TITLE
feat: 升级 AI 记账助手为智能财务对话界面

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -3077,6 +3077,83 @@ small.mono {
   gap: var(--space-3);
 }
 
+.chat-assistant-hero h2 {
+  margin: 0;
+  font-size: clamp(20px, 2.6vw, 28px);
+  line-height: 1.3;
+}
+
+.chat-assistant-hero p {
+  margin: 6px 0 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.chat-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.chat-overview-card {
+  border: 1px solid color-mix(in srgb, var(--color-primary-border) 58%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-elevated);
+  padding: 10px 12px;
+  display: grid;
+  gap: 3px;
+}
+
+.chat-overview-card span {
+  font-size: var(--font-xs);
+  color: var(--color-text-secondary);
+}
+
+.chat-overview-card strong {
+  font-size: var(--font-lg);
+  color: var(--color-text);
+}
+
+.chat-auto-insight-block {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border-light);
+  background: color-mix(in srgb, var(--color-bg-elevated) 92%, var(--color-primary-bg));
+}
+
+.chat-auto-insight-block p {
+  margin: 0;
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+}
+
+.chat-auto-insight-block strong {
+  color: var(--color-text);
+}
+
+.chat-insight-list {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.chat-insight-list p {
+  margin: 0;
+  border-radius: var(--radius-md);
+  padding: 7px 10px;
+  border: 1px solid var(--color-border-light);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+  font-size: var(--font-sm);
+}
+
+.chat-insight-list .chat-risk-alert {
+  border-color: var(--color-warning-border);
+  background: color-mix(in srgb, var(--color-warning-bg) 70%, #fff 30%);
+  color: var(--color-warning);
+}
+
 .chat-preset-head {
   display: flex;
   align-items: center;
@@ -3100,28 +3177,29 @@ small.mono {
 
 .chat-preset-list {
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-2);
 }
 
 .chat-preset-item {
-  text-align: left;
+  text-align: center;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--color-bg-elevated) 80%, var(--color-primary-bg));
+  border-radius: var(--radius-full);
+  background: var(--color-bg-elevated);
   color: var(--color-text);
-  padding: 10px 12px;
+  padding: 10px 14px;
   font-size: var(--font-sm);
-  line-height: 1.45;
+  line-height: 1.2;
   transition:
-    transform var(--transition-fast),
     border-color var(--transition-fast),
-    box-shadow var(--transition-fast);
+    box-shadow var(--transition-fast),
+    background var(--transition-fast);
 }
 
 .chat-preset-item:hover {
-  transform: translateY(-1px);
+  background: var(--color-primary-bg);
   border-color: var(--color-primary-border);
-  box-shadow: var(--shadow-xs);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary-bg) 45%, transparent);
 }
 
 /* ---------- Input Bar ---------- */
@@ -3271,8 +3349,8 @@ small.mono {
 .chat-input-textarea {
   flex: 1;
   resize: none;
-  min-height: 40px;
-  max-height: 150px;
+  min-height: 56px;
+  max-height: 170px;
   font-family: var(--font-sans);
   font-size: var(--font-base);
   line-height: var(--leading-normal);
@@ -3344,9 +3422,9 @@ small.mono {
   font-size: 20px;
   padding: 0;
   flex-shrink: 0;
-  border: 1px solid var(--color-primary-border);
-  background: var(--color-primary-bg);
-  color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: #fff;
 }
 
 .chat-send-btn:hover:not(:disabled) {
@@ -3356,7 +3434,7 @@ small.mono {
 }
 
 .chat-send-btn:disabled {
-  border-color: var(--color-border-light);
+  border-color: var(--color-border);
   background: var(--color-bg-subtle);
   color: var(--color-text-placeholder);
   cursor: not-allowed;
@@ -3418,6 +3496,11 @@ small.mono {
     padding: var(--space-3);
   }
 
+  .chat-overview-grid,
+  .chat-preset-list {
+    grid-template-columns: 1fr;
+  }
+
   .chat-kawaii-amount {
     font-size: 30px;
   }
@@ -3470,8 +3553,8 @@ small.mono {
   }
 
   .chat-input-textarea {
-    min-height: 32px;
-    max-height: 90px;
+    min-height: 44px;
+    max-height: 104px;
     font-size: var(--font-sm);
     padding: var(--space-2) var(--space-3);
   }

--- a/src/pages/assistant/AssistantPage.tsx
+++ b/src/pages/assistant/AssistantPage.tsx
@@ -20,15 +20,21 @@ import type { Category } from '../../entities/category/types';
 
 function inputPlaceholder(
   status: ReturnType<typeof useAssistantWorkbench>['status'],
-  hasApiKey: boolean
+  hasApiKey: boolean,
+  mode: AssistantMode
 ): string {
   if (!hasApiKey) return '请先在设置中配置 API Key';
 
+  const assistantHint = '例如：我这个月花多了吗？\n例如：餐饮支出占比多少？';
+  const bookkeepingHint = '比如：今天午饭15元，用支付宝（会自动识别分类）';
+
   switch (status) {
     case 'idle':
-      return '等待输入内容 · 比如：今天午饭15元，用支付宝（会自动识别分类）';
+      return mode === 'assistant' ? assistantHint : `等待输入内容 · ${bookkeepingHint}`;
     case 'ready':
-      return '可开始识别 · 按 Enter 发送，Shift + Enter 换行';
+      return mode === 'assistant'
+        ? `支持自然语言提问 · 按 Enter 发送，Shift + Enter 换行\n${assistantHint}`
+        : '可开始识别 · 按 Enter 发送，Shift + Enter 换行';
     case 'recognizing':
       return '模型识别中，请稍候…';
     case 'preview':
@@ -40,7 +46,7 @@ function inputPlaceholder(
     case 'error':
       return '识别失败，请调整描述后重试';
     default:
-      return '比如：今天午饭15元，用支付宝（会自动识别分类）';
+      return mode === 'assistant' ? assistantHint : bookkeepingHint;
   }
 }
 
@@ -219,8 +225,9 @@ const ANALYSIS_SHORTCUT_SEEDS = [
     prompt: '请按月对比我最近3个月的收入、支出和结余变化，指出趋势拐点，并说明最可能的影响因素。'
   },
   {
-    label: '高频标签花费洞察',
-    prompt: '请识别我消费中出现频率最高的标签或场景，评估其累计成本和节省空间，并给出优先级排序。'
+    label: '大额支出识别',
+    prompt:
+      '请识别我最近3个月中金额异常偏高的支出，标注时间、分类、金额及可能原因，并给出下月规避策略。'
   }
 ];
 
@@ -416,6 +423,12 @@ export function AssistantPage() {
   const [presetQuestions, setPresetQuestions] = useState<PresetQuestion[]>([]);
   const [loadingPresets, setLoadingPresets] = useState(false);
   const [chatHistory, setChatHistory] = useState<ChatHistoryItem[]>(() => readChatHistory(mode));
+  const todayKey = new Date().toISOString().slice(0, 10);
+  const thisMonthKey = todayKey.slice(0, 7);
+  const previousMonthDate = new Date();
+  previousMonthDate.setMonth(previousMonthDate.getMonth() - 1);
+  const previousMonthKey = `${previousMonthDate.getFullYear()}-${String(previousMonthDate.getMonth() + 1).padStart(2, '0')}`;
+
   const latestTransaction = useMemo(
     () =>
       [...transactions]
@@ -441,6 +454,81 @@ export function AssistantPage() {
     () => wb.entries.filter((item) => item.duplicateTxId).length,
     [wb.entries]
   );
+
+  const assistantOverview = useMemo(() => {
+    const validRows = transactions.filter(
+      (item) => item.type === 'income' || item.type === 'expense'
+    );
+    const todayRows = validRows.filter((item) => item.date.slice(0, 10) === todayKey);
+    const todayIncome = todayRows
+      .filter((item) => item.type === 'income')
+      .reduce((sum, item) => sum + item.amount, 0);
+    const todayExpense = todayRows
+      .filter((item) => item.type === 'expense')
+      .reduce((sum, item) => sum + item.amount, 0);
+    const todayNet = todayIncome - todayExpense;
+
+    const monthRows = validRows.filter((item) => item.date.startsWith(thisMonthKey));
+    const prevMonthRows = validRows.filter((item) => item.date.startsWith(previousMonthKey));
+    const monthExpense = monthRows
+      .filter((item) => item.type === 'expense')
+      .reduce((sum, item) => sum + item.amount, 0);
+    const prevMonthExpense = prevMonthRows
+      .filter((item) => item.type === 'expense')
+      .reduce((sum, item) => sum + item.amount, 0);
+    const monthIncome = monthRows
+      .filter((item) => item.type === 'income')
+      .reduce((sum, item) => sum + item.amount, 0);
+    const prevMonthIncome = prevMonthRows
+      .filter((item) => item.type === 'income')
+      .reduce((sum, item) => sum + item.amount, 0);
+
+    const expenseDeltaPct =
+      prevMonthExpense > 0 ? ((monthExpense - prevMonthExpense) / prevMonthExpense) * 100 : 0;
+    const incomeDeltaPct =
+      prevMonthIncome > 0 ? ((monthIncome - prevMonthIncome) / prevMonthIncome) * 100 : 0;
+
+    const recentExpenseRows = [...validRows]
+      .filter((item) => item.type === 'expense')
+      .sort((a, b) => +new Date(b.date) - +new Date(a.date))
+      .slice(0, 30);
+    const avgExpense =
+      recentExpenseRows.length > 0
+        ? recentExpenseRows.reduce((sum, item) => sum + item.amount, 0) / recentExpenseRows.length
+        : 0;
+    const abnormalRow = recentExpenseRows.find(
+      (item) => item.amount >= Math.max(avgExpense * 2.2, 500)
+    );
+
+    const monthBalance = monthIncome - monthExpense;
+    const insights = [
+      `本月累计支出 ¥${monthExpense.toFixed(2)}，较上月${expenseDeltaPct >= 0 ? '上升' : '下降'} ${Math.abs(expenseDeltaPct).toFixed(1)}%。`,
+      `本月收入趋势${incomeDeltaPct >= 0 ? '向上' : '回落'}，变化幅度 ${Math.abs(incomeDeltaPct).toFixed(1)}%，建议同步调整预算。`,
+      `当前月净额 ¥${monthBalance.toFixed(2)}，${monthBalance >= 0 ? '收支结构整体稳健。' : '建议关注可压缩支出项。'}`
+    ];
+
+    return {
+      todayIncome,
+      todayExpense,
+      todayNet,
+      monthlySummary:
+        monthExpense > 0
+          ? `本月消费 ¥${monthExpense.toFixed(2)}，主要建议聚焦高频小额与突发大额两类支出。`
+          : '本月消费数据较少，建议先连续记录 7 天后再进行结构分析。',
+      incomeTrend:
+        prevMonthIncome > 0
+          ? `收入较上月${incomeDeltaPct >= 0 ? '增长' : '下降'} ${Math.abs(incomeDeltaPct).toFixed(1)}%。`
+          : '收入趋势基线不足，建议持续记录每笔收入来源。',
+      abnormalReminder: abnormalRow
+        ? `发现异常支出：${abnormalRow.note || '未备注'} ¥${abnormalRow.amount.toFixed(2)}（${abnormalRow.date.slice(5)}）。`
+        : '暂无明显异常支出，当前波动在正常区间。',
+      insights,
+      riskAlert:
+        monthBalance < 0
+          ? '风险提示：本月净额为负，建议优先削减非必要消费并预留还款缓冲。'
+          : '风险提示：当前净额为正，但仍建议为突发支出预留至少 10% 安全垫。'
+    };
+  }, [previousMonthKey, thisMonthKey, todayKey, transactions]);
 
   // 每次状态或消息变化后，自动将视图滚动到底部，保持聊天体验。
   useEffect(() => {
@@ -771,8 +859,44 @@ export function AssistantPage() {
             </section>
           ) : (
             <section className="chat-kawaii-panel chat-assistant-panel">
-              <div className="chat-kawaii-topline">今天 {todayLabel}</div>
-              <div className="chat-kawaii-sub">先看数据，再发问，一次就问到重点。</div>
+              <div className="chat-assistant-hero">
+                <h2>🤖 你好，我是你的财务助手</h2>
+                <p>先看关键数据，再像聊天一样提问，我会主动给你可执行建议。</p>
+              </div>
+              <div className="chat-overview-grid" aria-label="今日概览">
+                <article className="chat-overview-card">
+                  <span>今日收入</span>
+                  <strong>¥{assistantOverview.todayIncome.toFixed(2)}</strong>
+                </article>
+                <article className="chat-overview-card">
+                  <span>今日支出</span>
+                  <strong>¥{assistantOverview.todayExpense.toFixed(2)}</strong>
+                </article>
+                <article className="chat-overview-card">
+                  <span>今日净额</span>
+                  <strong>¥{assistantOverview.todayNet.toFixed(2)}</strong>
+                </article>
+              </div>
+              <div className="chat-auto-insight-block">
+                <p>
+                  <strong>本月消费总结：</strong>
+                  {assistantOverview.monthlySummary}
+                </p>
+                <p>
+                  <strong>收入趋势变化：</strong>
+                  {assistantOverview.incomeTrend}
+                </p>
+                <p>
+                  <strong>异常支出提醒：</strong>
+                  {assistantOverview.abnormalReminder}
+                </p>
+              </div>
+              <div className="chat-insight-list" aria-label="主动洞察">
+                {assistantOverview.insights.map((insight) => (
+                  <p key={insight}>💡 {insight}</p>
+                ))}
+                <p className="chat-risk-alert">⚠️ {assistantOverview.riskAlert}</p>
+              </div>
               <div className="chat-preset-head">
                 <strong>个性化预设问题</strong>
                 <button
@@ -809,7 +933,11 @@ export function AssistantPage() {
                 {mode === 'bookkeeping' ? 'AI 记账助手' : 'AI 问答助手'}
               </div>
               <div className="chat-msg-content">
-                <p>输入一句话或贴截图，我会帮你快速生成可保存账单。</p>
+                <p>
+                  {mode === 'assistant'
+                    ? `今天 ${todayLabel}，我已为你准备好今日概览与主动洞察，直接用自然语言继续问我。`
+                    : '输入一句话或贴截图，我会帮你快速生成可保存账单。'}
+                </p>
               </div>
             </div>
           </article>
@@ -962,8 +1090,8 @@ export function AssistantPage() {
           <textarea
             ref={wb.textareaRef}
             className="chat-input-textarea"
-            rows={2}
-            placeholder={inputPlaceholder(wb.status, wb.hasApiKey)}
+            rows={3}
+            placeholder={inputPlaceholder(wb.status, wb.hasApiKey, mode)}
             value={wb.textInput}
             onChange={(e) => wb.setTextInput(e.target.value)}
             onPaste={(e) => void wb.handlePasteImage(e)}


### PR DESCRIPTION
### Motivation
- 将原有的“AI 记账助手”从单一功能入口升级为更具对话感和主动洞察能力的“智能财务助手”，以便打开页面即可获得可执行的财务洞察并鼓励自然语言问答。

### Description
- 在 `src/pages/assistant/AssistantPage.tsx` 中新增助手欢迎区、今日概览三张卡（今日收入/今日支出/今日净额）、自动生成的“本月消费总结/收入趋势/异常支出提醒”，并基于本地交易数据计算并展示 3 条洞察与 1 条风险提示。 
- 增强输入体验：将输入框高度提升（`rows` 从 2 改为 3 并调整 CSS 尺寸）、占位文本改为面向自然语言提问示例，并保留 `Enter` 发送 / `Shift+Enter` 换行交互。 
- 优化预设问题区为两列网格与胶囊按钮样式，增加 hover 背景变化并将快捷项之一替换为“大额支出识别”。
- 视觉样式调整汇总在 `src/app/styles/global.css`：新增欢迎/概览/洞察卡片样式、预设按键胶囊化、发送按钮改为主色实心、移动端自适应行为保持单列。 

### Testing
- 运行 `npm run lint`，结果通过（无错误）。
- 运行 `npm run build`（`tsc --noEmit && vite build`），构建成功且产物生成正常。 
- 使用自动化浏览器脚本加载 `/assistant` 页面并截取页面快照以做 UI smoke 验证，截图已生成用于人工核对。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6992a52ab650833186d71af3916b501f)