### PR TITLE
fix: guard backup/restore actions until finance store hydration completes

### DIFF
--- a/src/pages/database-settings/DatabaseSettingsPage.tsx
+++ b/src/pages/database-settings/DatabaseSettingsPage.tsx
@@ -22,6 +22,7 @@ import { Toast, ToastVariant } from '../../shared/ui/Toast';
 type BillSource = 'wechat' | 'alipay';
 
 export function DatabaseSettingsPage() {
+  const hasHydrated = useFinanceStore((s) => s.hasHydrated);
   const transactions = useFinanceStore((s) => s.transactions);
   const categories = useFinanceStore((s) => s.categories);
   const accounts = useFinanceStore((s) => s.accounts);
@@ -79,6 +80,7 @@ export function DatabaseSettingsPage() {
     }
 
     try {
+      ensureHydrated();
       const text = await file.text();
       const payload = parseFinanceBackupPayload(text);
       replaceAllData(payload.data);
@@ -175,8 +177,15 @@ export function DatabaseSettingsPage() {
     }
   };
 
+  const ensureHydrated = () => {
+    if (!hasHydrated) {
+      throw new Error('本地数据仍在加载中，请稍后重试');
+    }
+  };
+
   const handleWebdavUpload = async () => {
     try {
+      ensureHydrated();
       validateWebdav();
       setBusy(true);
       const payload = createFinanceBackupPayload({ transactions, categories, accounts });
@@ -192,6 +201,7 @@ export function DatabaseSettingsPage() {
 
   const handleWebdavDownload = async () => {
     try {
+      ensureHydrated();
       validateWebdav();
       setBusy(true);
       const payload = await webdavDownloadBackup(webdav);

--- a/src/shared/store/useFinanceStore.ts
+++ b/src/shared/store/useFinanceStore.ts
@@ -7,6 +7,7 @@ import { syncChangeIfNeeded } from '../lib/dataSync';
 import { generateId } from '../lib/id';
 
 interface FinanceState {
+  hasHydrated: boolean;
   transactions: TransactionItem[];
   categories: Category[];
   accounts: Account[];
@@ -147,6 +148,7 @@ function computeAccountBalances(accounts: Account[], transactions: TransactionIt
 export const useFinanceStore = create<FinanceState>()(
   persist(
     (set) => ({
+      hasHydrated: false,
       transactions: defaultTransactions,
       categories: defaultCategories,
       accounts: defaultAccounts,
@@ -305,6 +307,9 @@ export const useFinanceStore = create<FinanceState>()(
     {
       name: 'ledgerflow-finance',
       version: 2,
+      onRehydrateStorage: () => () => {
+        useFinanceStore.setState({ hasHydrated: true });
+      },
       merge: (persistedState, currentState) => {
         const incoming = (persistedState as Partial<FinanceState>) || {};
         const categories = Array.isArray(incoming.categories)
@@ -318,6 +323,7 @@ export const useFinanceStore = create<FinanceState>()(
         return {
           ...currentState,
           ...incoming,
+          hasHydrated: true,
           categories: compacted.categories,
           transactions: compacted.transactions,
           accounts: computeAccountBalances(


### PR DESCRIPTION
### Motivation
- Restores performed before the persisted finance store finishes hydrating can be overwritten by the later merge/hydration step, causing recovered data to appear lost after a refresh.
- Provide a clear guard so UI restore/sync actions do not run while the local store is still rehydrating.

### Description
- Add a `hasHydrated` flag to `useFinanceStore` and initialize it in the store state. (`src/shared/store/useFinanceStore.ts`)
- Mark hydration completion using `persist.onRehydrateStorage` and ensure the `merge` result also sets `hasHydrated: true` to reliably indicate persistence has loaded. (`src/shared/store/useFinanceStore.ts`)
- Add an `ensureHydrated()` check in `DatabaseSettingsPage` and call it before JSON import and WebDAV upload/download to block restore/sync actions until hydration completes, surfacing a user-friendly error via existing toast behavior. (`src/pages/database-settings/DatabaseSettingsPage.tsx`)

### Testing
- Ran `npm run build` (TypeScript check + `vite build`) and it completed successfully.
- Pre-commit tasks (`prettier` and `eslint --fix`) ran during commit and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992f9054b3083288a44ec789e21bbd2)