### PR TITLE
fix: 修复暗黑模式下账单条目悬浮发白问题

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -1157,7 +1157,7 @@ tr:hover td {
 }
 
 .transaction-row-clickable:hover td {
-  background: #f5f6f8;
+  background: var(--color-bg-subtle);
 }
 
 .transaction-table-wrap tbody td {


### PR DESCRIPTION
### Motivation
- 交易列表中可点击的行在悬浮/拖动经过时使用了硬编码浅色 `#f5f6f8`，导致暗黑主题下出现发白，需要改为使用主题变量以保持明暗主题一致性。

### Description
- 将 `src/app/styles/global.css` 中 `.transaction-row-clickable:hover td` 的背景从 `#f5f6f8` 改为 `var(--color-bg-subtle)` 以使用主题色。

### Testing
- 已运行 `npm run lint`，并通过；已用 `npm run dev` 启动并用 Playwright 脚本在暗黑主题下截图验证悬浮样式不再发白，验证通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992f93ee92883289fb745b244e0a180)