### PR TITLE
fix: 修复分类跳转使用分类 ID 进行筛选

### DIFF
--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -425,13 +425,13 @@ export function TransactionsPage() {
       return;
     }
 
-    const matchedCategory = categories.find((item) => item.id === categoryId);
-    if (!matchedCategory) {
+    const hasCategory = categories.some((item) => item.id === categoryId);
+    if (!hasCategory) {
       return;
     }
 
     setQuickFilters((prev) =>
-      prev.category === matchedCategory.name ? prev : { ...prev, category: matchedCategory.name }
+      prev.category === categoryId ? prev : { ...prev, category: categoryId }
     );
     setPage(1);
   }, [categories, searchParams, setPage]);


### PR DESCRIPTION
### Motivation
- 修复从“分类与标签管理”页点击分类条数跳转 `/transactions?categoryId=...` 后交易页未正确筛选的问题，原因是页面把 `categoryId` 映射为分类名称写入快速筛选，但实际筛选逻辑按分类 ID 比较。

### Description
- 在 `src/pages/transactions/TransactionsPage.tsx` 中改为先校验分类是否存在（使用 `categories.some(...)`），并将 `quickFilters.category` 直接设置为 `categoryId` 而不是分类名称，从而保证通过 URL 跳转传入的 `categoryId` 能命中筛选。

### Testing
- 运行了单元测试 `npm test -- --run src/features/transactions/model/categoryQuickFilter.test.ts`，结果通过（3/3）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992fb527da883288fa58a4989293eba)