### PR TITLE
refactor: 移除 MySQL/PostgreSQL 支持，统一为 Redis / 备份方案

### DIFF
--- a/src/entities/connection/types.ts
+++ b/src/entities/connection/types.ts
@@ -1,4 +1,4 @@
-export type ConnectionType = 'postgresql' | 'mysql' | 'redis';
+export type ConnectionType = 'redis';
 
 export interface ConnectionPoolConfig {
   min: number;

--- a/src/features/connection-config/model/connectionDefaults.ts
+++ b/src/features/connection-config/model/connectionDefaults.ts
@@ -1,13 +1,11 @@
 import { ConnectionFormValues } from './connectionFormSchema';
 
 const DEFAULT_PORT: Record<ConnectionFormValues['type'], number> = {
-  postgresql: 5432,
-  mysql: 3306,
   redis: 6379
 };
 
 export function getConnectionDefaults(
-  type: ConnectionFormValues['type'] = 'mysql'
+  type: ConnectionFormValues['type'] = 'redis'
 ): ConnectionFormValues {
   return {
     name: '',

--- a/src/features/connection-config/model/connectionFormSchema.ts
+++ b/src/features/connection-config/model/connectionFormSchema.ts
@@ -17,7 +17,7 @@ export const connectionFormSchema = z
   .object({
     id: z.string().optional(),
     name: z.string().min(2, '名称至少 2 个字符'),
-    type: z.enum(['postgresql', 'mysql', 'redis']),
+    type: z.enum(['redis']),
     host: z.string().min(1, '主机必填'),
     port: z.coerce.number().int().min(1, '端口必须在 1-65535').max(65535, '端口必须在 1-65535'),
     username: z.string().optional(),
@@ -50,11 +50,7 @@ export const connectionFormSchema = z
       return;
     }
 
-    const requiresCred = value.type !== 'redis';
-    if (requiresCred && !value.username) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['username'], message: '用户名必填' });
-    }
-    if (requiresCred && !value.database) {
+    if (!value.database) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['database'], message: '数据库名必填' });
     }
   });

--- a/src/features/connection-config/model/connectionString.ts
+++ b/src/features/connection-config/model/connectionString.ts
@@ -6,9 +6,7 @@ export interface ParsedConnectionString {
   database?: string;
 }
 
-const PROTOCOL_MAP: Record<'postgresql' | 'mysql' | 'redis', string[]> = {
-  postgresql: ['postgres', 'postgresql'],
-  mysql: ['mysql'],
+const PROTOCOL_MAP: Record<'redis', string[]> = {
   redis: ['redis', 'rediss']
 };
 
@@ -16,7 +14,7 @@ function normalizeProtocol(raw: string) {
   return raw.replace(':', '').toLowerCase();
 }
 
-export function parseConnectionString(connectionString: string, type: 'postgresql' | 'mysql' | 'redis') {
+export function parseConnectionString(connectionString: string, type: 'redis') {
   try {
     const url = new URL(connectionString);
     const protocol = normalizeProtocol(url.protocol);

--- a/src/features/connection-config/ui/ConnectionConfigForm.tsx
+++ b/src/features/connection-config/ui/ConnectionConfigForm.tsx
@@ -17,7 +17,11 @@ function getDefaultsByType(type: ConnectionFormValues['type']) {
   return getConnectionDefaults(type);
 }
 
-export function ConnectionConfigForm({ initialValues, onSubmit, onCancel }: ConnectionConfigFormProps) {
+export function ConnectionConfigForm({
+  initialValues,
+  onSubmit,
+  onCancel
+}: ConnectionConfigFormProps) {
   const addLog = useDebugLogStore((s) => s.addLog);
   const [testing, setTesting] = useState(false);
 
@@ -25,8 +29,6 @@ export function ConnectionConfigForm({ initialValues, onSubmit, onCancel }: Conn
     resolver: zodResolver(connectionFormSchema),
     defaultValues: initialValues ?? getConnectionDefaults()
   });
-
-  const watchType = form.watch('type');
 
   function applyConnectionString() {
     const values = form.getValues();
@@ -80,12 +82,12 @@ export function ConnectionConfigForm({ initialValues, onSubmit, onCancel }: Conn
           <div className="grid grid-3">
             <div className="field">
               <label title="用于区分不同环境连接">名称</label>
-              <input {...form.register('name')} placeholder="例如：生产 PG 只读" />
+              <input {...form.register('name')} placeholder="例如：Redis 生产实例" />
               <small className="error">{form.formState.errors.name?.message}</small>
             </div>
 
             <div className="field">
-              <label title="切换类型后会自动填充端口与默认字段">数据库类型</label>
+              <label title="当前仅支持 Redis，切换会自动填充默认端口">数据库类型</label>
               <select
                 {...form.register('type')}
                 onChange={(e) => {
@@ -95,13 +97,9 @@ export function ConnectionConfigForm({ initialValues, onSubmit, onCancel }: Conn
                   form.setValue('port', getPortByType(type));
                   form.setValue('host', defaults.host);
                   form.setValue('database', defaults.database);
-                  if (type === 'redis') {
-                    form.setValue('username', '');
-                  }
+                  form.setValue('username', '');
                 }}
               >
-                <option value="mysql">MySQL</option>
-                <option value="postgresql">PostgreSQL</option>
                 <option value="redis">Redis</option>
               </select>
             </div>
@@ -120,34 +118,35 @@ export function ConnectionConfigForm({ initialValues, onSubmit, onCancel }: Conn
             </div>
             <div className="field">
               <label title="系统会根据数据库类型自动填充默认端口">Port</label>
-              <input type="number" {...form.register('port')} placeholder="5432" />
+              <input type="number" {...form.register('port')} placeholder="6379" />
               <small className="error">{form.formState.errors.port?.message}</small>
             </div>
             <div className="field">
-              <label title="连接后默认访问的数据库">数据库名</label>
-              <input {...form.register('database')} placeholder={watchType === 'redis' ? '0' : 'ledgerflow'} />
+              <label title="Redis 数据库编号">数据库编号</label>
+              <input {...form.register('database')} placeholder="0" />
               <small className="error">{form.formState.errors.database?.message}</small>
             </div>
           </div>
 
-          {watchType !== 'redis' && (
-            <div className="grid grid-3">
-              <div className="field">
-                <label title="数据库登录用户名">用户名</label>
-                <input {...form.register('username')} placeholder="postgres / root" />
-                <small className="error">{form.formState.errors.username?.message}</small>
-              </div>
-              <div className="field">
-                <label title="密码仅用于连接，不以明文存储">密码</label>
-                <input type="password" {...form.register('password')} placeholder="请输入密码" />
-              </div>
+          <div className="grid grid-3">
+            <div className="field">
+              <label title="Redis 用户名（大多数场景可留空）">用户名</label>
+              <input {...form.register('username')} placeholder="可选，默认留空" />
+              <small className="error">{form.formState.errors.username?.message}</small>
             </div>
-          )}
+            <div className="field">
+              <label title="密码仅用于连接，不以明文存储">密码</label>
+              <input type="password" {...form.register('password')} placeholder="请输入密码" />
+            </div>
+          </div>
 
           <div className="field">
             <label title="连接串优先级高于离散字段">连接串（可选）</label>
             <div className="row connection-inline-row">
-              <input {...form.register('connectionString')} placeholder="postgres://user:pass@host:5432/db" />
+              <input
+                {...form.register('connectionString')}
+                placeholder="redis://:password@localhost:6379/0"
+              />
               <button type="button" onClick={applyConnectionString}>
                 解析连接串
               </button>
@@ -214,12 +213,20 @@ export function ConnectionConfigForm({ initialValues, onSubmit, onCancel }: Conn
             }}
           />
 
-          <button className="primary" type="submit" disabled={testing || form.formState.isSubmitting}>
+          <button
+            className="primary"
+            type="submit"
+            disabled={testing || form.formState.isSubmitting}
+          >
             {form.formState.isSubmitting ? '保存中...' : '保存配置'}
           </button>
 
           {onCancel && (
-            <button type="button" onClick={onCancel} disabled={testing || form.formState.isSubmitting}>
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={testing || form.formState.isSubmitting}
+            >
               取消
             </button>
           )}

--- a/src/features/connection-config/ui/ConnectionConfigManager.tsx
+++ b/src/features/connection-config/ui/ConnectionConfigManager.tsx
@@ -35,7 +35,7 @@ export function ConnectionConfigManager() {
         style={{ justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}
       >
         <div>
-          <h3 style={{ margin: 0 }}>连接配置管理（PG / MySQL / Redis）</h3>
+          <h3 style={{ margin: 0 }}>连接配置管理（Redis）</h3>
           <p
             style={{
               margin: '6px 0 0',

--- a/src/features/connection-config/ui/ConnectionTestButton.test.tsx
+++ b/src/features/connection-config/ui/ConnectionTestButton.test.tsx
@@ -15,13 +15,13 @@ vi.mock('../model/connectionTest', () => ({
 }));
 
 const baseValues = {
-  name: 'pg-dev',
-  type: 'postgresql' as const,
+  name: 'redis-dev',
+  type: 'redis' as const,
   host: 'localhost',
-  port: 5432,
-  username: 'postgres',
+  port: 6379,
+  username: '',
   password: '123456',
-  database: 'ledger',
+  database: '0',
   connectionString: '',
   enabled: true,
   timeoutMs: 1200,

--- a/src/features/connection-config/ui/connectionFormSchema.test.ts
+++ b/src/features/connection-config/ui/connectionFormSchema.test.ts
@@ -4,8 +4,8 @@ import { connectionFormSchema } from '../model/connectionFormSchema';
 describe('connectionFormSchema', () => {
   it('应拒绝非法端口与缺失必填字段', () => {
     const result = connectionFormSchema.safeParse({
-      name: 'pg-prod',
-      type: 'postgresql',
+      name: 'redis-prod',
+      type: 'redis',
       host: 'db.example.com',
       port: 70000,
       username: '',
@@ -22,21 +22,20 @@ describe('connectionFormSchema', () => {
     if (!result.success) {
       const errors = result.error.flatten().fieldErrors;
       expect(errors.port?.[0]).toContain('1-65535');
-      expect(errors.username?.[0]).toContain('必填');
       expect(errors.database?.[0]).toContain('必填');
     }
   });
 
   it('应支持解析合法连接串并通过校验', () => {
     const result = connectionFormSchema.safeParse({
-      name: 'mysql-dev',
-      type: 'mysql',
+      name: 'redis-dev',
+      type: 'redis',
       host: 'localhost',
-      port: 3306,
+      port: 6379,
       username: '',
       password: '',
       database: '',
-      connectionString: 'mysql://root:pass@127.0.0.1:3306/ledger',
+      connectionString: 'redis://:pass@127.0.0.1:6379/0',
       enabled: true,
       timeoutMs: 8000,
       pool: { min: 1, max: 10, idleTimeoutMs: 10000 },

--- a/src/pages/database-settings/DatabaseSettingsPage.tsx
+++ b/src/pages/database-settings/DatabaseSettingsPage.tsx
@@ -219,7 +219,7 @@ export function DatabaseSettingsPage() {
     <div>
       <section className="panel">
         <h2>备份设置</h2>
-        <p>已移除 MySQL / PostgreSQL / Redis 连接配置，当前统一使用备份与恢复方案。</p>
+        <p>已移除在线数据库连接配置，当前统一使用备份与恢复方案。</p>
         <ul style={{ marginTop: 10, color: 'var(--color-text-secondary)', lineHeight: 1.7 }}>
           <li>支持本地 JSON 一键导出与导入。</li>
           <li>支持导入微信 / 支付宝账单 CSV / XLSX。</li>

--- a/src/shared/api/syncClient.ts
+++ b/src/shared/api/syncClient.ts
@@ -12,7 +12,6 @@ export interface FinanceSyncData {
 export interface SyncLocalDataRequest {
   source: 'manual' | 'auto';
   strategy?: 'append' | 'upsert';
-  targetDbType?: 'postgresql' | 'mysql';
   data: FinanceSyncData;
 }
 
@@ -28,7 +27,6 @@ export interface SyncChangeRequest {
   action: 'insert' | 'update' | 'delete';
   row?: unknown;
   id?: string;
-  targetDbType?: 'postgresql' | 'mysql';
   happenedAt: string;
 }
 

--- a/src/shared/lib/dataSync.ts
+++ b/src/shared/lib/dataSync.ts
@@ -1,65 +1,16 @@
-import { ConnectionConfig } from '../../entities/connection/types';
-import { listConnections } from '../../features/connection-config/model/connectionStorage';
-import { postSyncChange, SyncChangeRequest } from '../api/syncClient';
-import { useAppPreferences } from '../store/useAppPreferences';
-import { useDebugLogStore } from '../store/useDebugLogStore';
+import { SyncChangeRequest } from '../api/syncClient';
 
-export type SyncDbType = 'postgresql' | 'mysql';
-
-type SqlConnectionConfig = ConnectionConfig & { type: SyncDbType };
-
-function isSqlType(type: string): type is SyncDbType {
-  return type === 'postgresql' || type === 'mysql';
-}
-
-function listEnabledSqlConnections(): SqlConnectionConfig[] {
-  return listConnections().filter(
-    (item): item is SqlConnectionConfig => item.enabled && isSqlType(item.type)
-  );
-}
+export type SyncDbType = 'redis';
 
 export function hasEnabledSqlConnection() {
-  return listEnabledSqlConnections().length > 0;
+  return false;
 }
 
 export function resolveSyncTargetDbType(): SyncDbType | null {
-  const enabled = listEnabledSqlConnections();
-  if (enabled.length === 0) {
-    return null;
-  }
-
-  const preferred = useAppPreferences.getState().syncTargetDb;
-  const preferredMatched = enabled.find((item) => item.type === preferred);
-  if (preferredMatched) {
-    return preferredMatched.type;
-  }
-
-  return enabled[0].type;
+  return null;
 }
 
 export async function syncChangeIfNeeded(payload: Omit<SyncChangeRequest, 'happenedAt'>) {
-  const targetDbType = resolveSyncTargetDbType();
-  if (!targetDbType) {
-    return;
-  }
-
-  try {
-    const result = await postSyncChange({
-      ...payload,
-      targetDbType,
-      happenedAt: new Date().toISOString()
-    });
-
-    if (!result.ok) {
-      throw new Error(result.detail || result.message || '同步失败');
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : '数据库增量同步失败';
-    useDebugLogStore.getState().addLog({
-      action: '自动同步',
-      status: 'error',
-      dbType: targetDbType,
-      message
-    });
-  }
+  void payload;
+  return;
 }

--- a/src/shared/store/useAppPreferences.test.ts
+++ b/src/shared/store/useAppPreferences.test.ts
@@ -6,7 +6,6 @@ describe('useAppPreferences RSS subscriptions', () => {
     localStorage.removeItem('ledgerflow-preferences');
     useAppPreferences.setState({
       theme: 'system',
-      syncTargetDb: 'postgresql',
       rssSubscriptions: [
         {
           id: 'rss-financial-times-markets',

--- a/src/shared/store/useAppPreferences.ts
+++ b/src/shared/store/useAppPreferences.ts
@@ -3,8 +3,6 @@ import { persist } from 'zustand/middleware';
 import { AppTheme } from '../types/app';
 import { DebtItem, DebtType } from '../../features/debt/model/debtMetrics';
 
-export type SyncTargetDbPreference = 'postgresql' | 'mysql';
-
 export type RssSubscription = {
   id: string;
   title: string;
@@ -29,12 +27,10 @@ const DEFAULT_RSS_SUBSCRIPTIONS: RssSubscription[] = [
 
 interface AppPreferencesState {
   theme: AppTheme;
-  syncTargetDb: SyncTargetDbPreference;
   rssSubscriptions: RssSubscription[];
   debts: DebtItem[];
   monthlyIncome: number;
   setTheme: (theme: AppTheme) => void;
-  setSyncTargetDb: (target: SyncTargetDbPreference) => void;
   addRssSubscription: (payload: { title: string; url: string }) => { ok: boolean; reason?: string };
   removeRssSubscription: (id: string) => void;
   toggleRssSubscription: (id: string) => void;
@@ -66,12 +62,10 @@ export const useAppPreferences = create<AppPreferencesState>()(
   persist(
     (set) => ({
       theme: 'system',
-      syncTargetDb: 'postgresql',
       rssSubscriptions: DEFAULT_RSS_SUBSCRIPTIONS,
       debts: [],
       monthlyIncome: 0,
       setTheme: (theme) => set({ theme }),
-      setSyncTargetDb: (target) => set({ syncTargetDb: target }),
       setMonthlyIncome: (income) => set({ monthlyIncome: Number.isFinite(income) ? income : 0 }),
       addRssSubscription: ({ title, url }) => {
         const normalizedUrl = normalizeFeedUrl(url);

--- a/src/shared/store/useDebugLogStore.ts
+++ b/src/shared/store/useDebugLogStore.ts
@@ -8,7 +8,7 @@ export interface DebugLogItem {
   timestamp: string;
   action: string;
   status: DebugLogStatus;
-  dbType?: 'postgresql' | 'mysql' | 'redis';
+  dbType?: 'redis';
   message: string;
 }
 

--- a/src/shared/store/useSyncStore.ts
+++ b/src/shared/store/useSyncStore.ts
@@ -1,8 +1,4 @@
 import { create } from 'zustand';
-import { postSyncLocalData } from '../api/syncClient';
-import { hasEnabledSqlConnection, resolveSyncTargetDbType } from '../lib/dataSync';
-import { useDebugLogStore } from './useDebugLogStore';
-import { useFinanceStore } from './useFinanceStore';
 
 export type SyncStatus = 'idle' | 'loading' | 'success' | 'error' | 'needs-config';
 
@@ -33,82 +29,11 @@ export const useSyncStore = create<SyncState>()((set) => ({
       progress: { synced: 0, total: 0 }
     }),
   syncToDatabase: async () => {
-    if (!hasEnabledSqlConnection()) {
-      set({
-        status: 'needs-config',
-        message: '当前未配置可用数据库连接',
-        detail: '可先继续本地记账，稍后在下方新增 MySQL / PostgreSQL 连接再一键迁移历史数据。'
-      });
-      return;
-    }
-
-    const targetDbType = resolveSyncTargetDbType();
-    if (!targetDbType) {
-      set({
-        status: 'needs-config',
-        message: '当前未配置可用数据库连接',
-        detail: '请先启用一个 MySQL 或 PostgreSQL 连接。'
-      });
-      return;
-    }
-
-    const state = useFinanceStore.getState();
-    const data = {
-      transactions: state.transactions,
-      accounts: state.accounts,
-      categories: state.categories
-    };
-    const total = data.transactions.length + data.accounts.length + data.categories.length;
-
     set({
-      status: 'loading',
-      message: '正在同步...',
-      detail: '',
-      progress: { synced: 0, total }
+      status: 'needs-config',
+      message: '在线数据库同步已移除',
+      detail: '当前版本仅支持本地备份、账单导入与 WebDAV 备份恢复。',
+      progress: { synced: 0, total: 0 }
     });
-
-    try {
-      const result = await postSyncLocalData({
-        source: 'manual',
-        strategy: 'upsert',
-        targetDbType,
-        data
-      });
-
-      if (!result.ok) {
-        throw new Error(result.detail || result.message || '数据同步失败');
-      }
-
-      const synced = typeof result.synced === 'number' ? result.synced : total;
-      set({
-        status: 'success',
-        message: '数据同步成功',
-        detail:
-          result.message ||
-          `本地数据已写入 ${targetDbType === 'postgresql' ? 'PostgreSQL' : 'MySQL'}`,
-        progress: { synced, total }
-      });
-
-      useDebugLogStore.getState().addLog({
-        action: '手动同步',
-        status: 'success',
-        dbType: targetDbType,
-        message: `同步成功：${synced}/${total} 条记录`
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : '数据同步失败';
-      set({
-        status: 'error',
-        message: '数据同步失败',
-        detail: message
-      });
-
-      useDebugLogStore.getState().addLog({
-        action: '手动同步',
-        status: 'error',
-        dbType: targetDbType,
-        message
-      });
-    }
   }
 }));


### PR DESCRIPTION
### Motivation

- 取消前端中 MySQL / PostgreSQL 的配置与同步通路，降低因无效 SQL 配置导致的数据同步失败和状态不一致风险。
- 将连接管理与校验收敛到 Redis，保留本地备份/导入与 WebDAV 恢复作为主要的数据迁移/备份途径，以保证数据稳定性。

### Description

- 将连接类型收敛为 Redis-only（`ConnectionType`、表单枚举、默认端口与连接串解析均改为只支持 Redis）。
- 将连接配置 UI 与校验更新为 Redis 场景（表单提示、示例连接串、端口 6379、数据库编号等）。
- 将在线数据库手动同步流程降级为安全提示（`useSyncStore` 返回提示“在线数据库同步已移除”），并把辅助的同步模块改为 no-op 实现以避免触发旧 SQL 同步逻辑（`dataSync` 模块不再列出 SQL 目标）。
- 清理与 SQL 目标相关的类型与偏好（移除 `targetDbType` / `syncTargetDb` 等字段），并同步更新受影响的测试用例与文案（数据库设置页文案改为“已移除在线数据库连接配置”）。
- 受影响的主要文件包括：`src/entities/connection/types.ts`、`src/features/connection-config/model/*`、`src/features/connection-config/ui/*`、`src/shared/lib/dataSync.ts`、`src/shared/store/useSyncStore.ts`、`src/shared/api/syncClient.ts`、`src/shared/store/useAppPreferences.ts`、若干测试文件等。

### Testing

- 运行了代码质量检查：`npm run lint`，结果通过（ESLint 无错误）。
- 进行了生产打包：`npm run build`，构建成功并生成 `dist`。
- 执行了单元测试：`npm run test`，所有测试文件通过（21 个测试文件，51 个测试用例全部通过）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992fab82bf48328a4d62e8d177a9019)