### PR TITLE
fix(layout): 移除展开侧栏时的空白顶栏占位

### DIFF
--- a/src/widgets/layout/AppLayout.tsx
+++ b/src/widgets/layout/AppLayout.tsx
@@ -105,6 +105,9 @@ export function AppLayout() {
   const [sidebarWidth, setSidebarWidth] = useState(260);
   const [menuOpen, setMenuOpen] = useState(false);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [isMobileViewport, setIsMobileViewport] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia('(max-width: 768px)').matches : false
+  );
 
   const draggingRef = useRef(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -176,6 +179,22 @@ export function AppLayout() {
       document.body.style.overflow = '';
     };
   }, [mobileNavOpen]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(max-width: 768px)');
+    const onViewportChange = (event: MediaQueryListEvent) => {
+      setIsMobileViewport(event.matches);
+    };
+
+    setIsMobileViewport(mediaQuery.matches);
+    mediaQuery.addEventListener('change', onViewportChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', onViewportChange);
+    };
+  }, []);
+
+  const shouldShowTopbar = collapsed || isMobileViewport;
 
   return (
     <div
@@ -253,51 +272,53 @@ export function AppLayout() {
       </aside>
 
       <div className="workspace">
-        <header className="workspace-topbar">
-          <div className="topbar-left" ref={menuRef}>
-            <button
-              type="button"
-              className="icon-btn mobile-nav-toggle"
-              onClick={() => setMobileNavOpen(true)}
-              aria-label="打开功能抽屉"
-            >
-              ☰
-            </button>
-            {collapsed ? (
-              <>
-                <button
-                  type="button"
-                  className="logo-circle"
-                  onClick={() => setMenuOpen((v) => !v)}
-                  aria-haspopup="menu"
-                  aria-expanded={menuOpen}
-                  aria-label="打开项目菜单"
-                >
-                  👤
-                </button>
-                {menuOpen ? (
-                  <div className="logo-menu" role="menu">
-                    {logoMenuItems.map((item) => (
-                      <Link
-                        key={item.to}
-                        to={item.to}
-                        className="logo-menu-item"
-                        onClick={() => setMenuOpen(false)}
-                      >
-                        <span className="logo-menu-icon">{item.icon}</span> {item.label}
-                      </Link>
-                    ))}
-                  </div>
-                ) : null}
+        {shouldShowTopbar ? (
+          <header className="workspace-topbar">
+            <div className="topbar-left" ref={menuRef}>
+              <button
+                type="button"
+                className="icon-btn mobile-nav-toggle"
+                onClick={() => setMobileNavOpen(true)}
+                aria-label="打开功能抽屉"
+              >
+                ☰
+              </button>
+              {collapsed ? (
+                <>
+                  <button
+                    type="button"
+                    className="logo-circle"
+                    onClick={() => setMenuOpen((v) => !v)}
+                    aria-haspopup="menu"
+                    aria-expanded={menuOpen}
+                    aria-label="打开项目菜单"
+                  >
+                    👤
+                  </button>
+                  {menuOpen ? (
+                    <div className="logo-menu" role="menu">
+                      {logoMenuItems.map((item) => (
+                        <Link
+                          key={item.to}
+                          to={item.to}
+                          className="logo-menu-item"
+                          onClick={() => setMenuOpen(false)}
+                        >
+                          <span className="logo-menu-icon">{item.icon}</span> {item.label}
+                        </Link>
+                      ))}
+                    </div>
+                  ) : null}
 
-                <div className="topbar-brand-copy compact">
-                  <h1>LedgerFlow</h1>
-                  <span>智能记账工作台</span>
-                </div>
-              </>
-            ) : null}
-          </div>
-        </header>
+                  <div className="topbar-brand-copy compact">
+                    <h1>LedgerFlow</h1>
+                    <span>智能记账工作台</span>
+                  </div>
+                </>
+              ) : null}
+            </div>
+          </header>
+        ) : null}
 
         <main className="content">
           <Outlet />


### PR DESCRIPTION
### Motivation
- 在聊天/助手页面顶部当侧边栏展开时会留出一个空白的 `workspace-topbar` 占位，影响可视高度，需要在桌面展开侧边栏时隐藏该顶栏以提升聊天窗口可用区域。

### Description
- 在 `src/widgets/layout/AppLayout.tsx` 中新增 `isMobileViewport` 状态并通过 `window.matchMedia('(max-width: 768px)')` 实时监听视口变化以区分移动端与桌面端。
- 添加 `shouldShowTopbar` 计算条件并将 `workspace-topbar` 的渲染改为仅在 `collapsed` 为 `true` 或 `isMobileViewport` 为 `true` 时才显示，从而在桌面侧边栏展开时不再输出空白顶栏。
- 保留原有移动端抽屉与折叠侧边栏场景的交互与入口逻辑，未改动其它布局或样式文件。

### Testing
- 运行 `npm run lint` 校验通过且没有错误。
- 运行 `npm run build` 打包成功且生成产物无异常。
- 启动本地并使用 Playwright 访问 `/assistant` 并截图确认顶部空白占位已消失（验证通过）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992feefc70083288aa8f30b01dfcacc)