### PR TITLE
fix(chat): align input bar with viewport bottom across devices

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -2367,6 +2367,7 @@ small.mono {
   display: flex;
   flex-direction: column;
   height: calc(100vh - var(--topbar-height));
+  height: calc(100dvh - var(--topbar-height));
   min-height: 0;
   margin: calc(var(--space-6) * -1);
   overflow: hidden;
@@ -3207,6 +3208,7 @@ small.mono {
   border-top: 1px solid var(--color-border);
   background: var(--color-bg-elevated);
   padding: 0;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   flex-shrink: 0;
 }
 
@@ -3475,8 +3477,9 @@ small.mono {
    ============================================================ */
 @media (max-width: 768px) {
   .chat-fullscreen {
-    margin: calc(var(--space-6) * -1);
-    height: calc(100vh - 60px);
+    margin: calc(var(--space-4) * -1);
+    height: calc(100vh - var(--topbar-height));
+    height: calc(100dvh - var(--topbar-height));
   }
 
   .chat-topbar {
@@ -3596,7 +3599,6 @@ small.mono {
 @media (max-width: 480px) {
   .chat-fullscreen {
     margin: calc(var(--space-4) * -1);
-    height: calc(100vh - 52px);
   }
 
   .chat-topbar {


### PR DESCRIPTION
### Motivation
- Ensure the assistant chat composer stays visually pinned to the bottom of the viewport on mobile and modern browsers where the visual viewport can change (address bar, home indicator), and avoid bottom offset on devices with safe areas.

### Description
- Updated `.chat-fullscreen` height to include a `100dvh` fallback: `height: calc(100vh - var(--topbar-height)); height: calc(100dvh - var(--topbar-height));` in `src/app/styles/global.css` to support dynamic viewport height.
- Added `padding-bottom: env(safe-area-inset-bottom, 0px);` to `.chat-input-bar` so the input area accounts for device safe-area insets.
- Adjusted mobile responsive rules to use `var(--topbar-height)` for height calculations and unified negative margin for small screens, removing a hard-coded `52px` mobile height to avoid inconsistent bottom alignment.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run build` and the production build finished successfully.
- Launched the dev server and captured an automated screenshot of `/assistant` to validate visual alignment (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699301a530648328a353c4e76c8b93ff)