### PR TITLE
优化侧边栏导航文案，提升可读性与专业感

### DIFF
--- a/src/widgets/layout/AppLayout.tsx
+++ b/src/widgets/layout/AppLayout.tsx
@@ -21,32 +21,32 @@ type QuickEntry = {
 
 const navSections: Array<{ title: string; items: NavItem[] }> = [
   {
-    title: 'AI 助手',
+    title: '智能助手',
     items: [
       { to: '/assistant', label: '记账助手', icon: '🤖' },
       { to: '/smart-budget', label: '智能预算', icon: '🧠' }
     ]
   },
   {
-    title: '交易数据',
+    title: '交易与洞察',
     items: [
-      { to: '/transactions', label: '交易详情', icon: '📋' },
-      { to: '/', label: '统计分析', icon: '📊', end: true }
+      { to: '/transactions', label: '交易流水', icon: '📋' },
+      { to: '/', label: '数据概览', icon: '📊', end: true }
     ]
   },
   {
-    title: '基础数据',
+    title: '账务管理',
     items: [
-      { to: '/categories-accounts', label: '账户/分类/标签', icon: '🗂️' },
+      { to: '/categories-accounts', label: '账户与分类', icon: '🗂️' },
       { to: '/repayment-management', label: '还款管理', icon: '💳' }
     ]
   },
   {
-    title: '杂项',
+    title: '系统服务',
     items: [
       { to: '/settings', label: '设置', icon: '⚙️' },
-      { to: '/exchange', label: '汇率数据', icon: '💱' },
-      { to: '/finance', label: '金融资讯', icon: '📰' },
+      { to: '/exchange', label: '汇率工具', icon: '💱' },
+      { to: '/finance', label: '市场资讯', icon: '📰' },
       { to: '/about', label: '关于', icon: 'ℹ️' }
     ]
   }
@@ -65,16 +65,16 @@ const logoMenuItems = [
  */
 const mobileQuickGroups: Array<{ title: string; items: QuickEntry[] }> = [
   {
-    title: '高频入口',
+    title: '常用功能',
     items: [
       { label: '记账助手', icon: '🤖', to: '/assistant' },
       { label: '智能预算', icon: '🧠', to: '/smart-budget' },
-      { label: '交易详情', icon: '📋', to: '/transactions' },
-      { label: '统计分析', icon: '📊', to: '/', end: true },
-      { label: '分类账户', icon: '🗂️', to: '/categories-accounts' },
+      { label: '交易流水', icon: '📋', to: '/transactions' },
+      { label: '数据概览', icon: '📊', to: '/', end: true },
+      { label: '账户与分类', icon: '🗂️', to: '/categories-accounts' },
       { label: '还款管理', icon: '💳', to: '/repayment-management' },
-      { label: '金融资讯', icon: '📰', to: '/finance' },
-      { label: '汇率数据', icon: '💱', to: '/exchange' }
+      { label: '市场资讯', icon: '📰', to: '/finance' },
+      { label: '汇率工具', icon: '💱', to: '/exchange' }
     ]
   },
   {


### PR DESCRIPTION
### Motivation
- 优化侧边栏和移动快捷入口的文案，使导航不沉闷同时保持专业与可读性。
- 保持桌面与移动端命名一致以减少用户认知负担。

### Description
- 将侧边栏分组标题从 `AI 助手`/`交易数据`/`基础数据`/`杂项` 改为 `智能助手`/`交易与洞察`/`账务管理`/`系统服务`。
- 调整若干菜单项文案，如 `交易详情` → `交易流水`、`统计分析` → `数据概览`、`账户/分类/标签` → `账户与分类`、`汇率数据` → `汇率工具`、`金融资讯` → `市场资讯`。
- 同步更新移动端 `mobileQuickGroups` 中的分组标题与条目以保持一致。
- 变更位于文件 `src/widgets/layout/AppLayout.tsx`。

### Testing
- 运行 `npm run lint` 并通过，未发现 lint 错误。
- 启动开发服务器 `npm run dev` 成功并可访问，辅助脚本使用 Playwright 自动截取了页面快照以验证侧边栏显示且操作成功。
- 本次变更未运行单元测试套件 `vitest`，因仅涉及文案调整。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993025286808328afc52e48bfb6e11d)