### PR TITLE
fix(assistant): remove bottom gap in chat layout

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -2366,12 +2366,17 @@ small.mono {
 .chat-fullscreen {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - var(--topbar-height));
-  height: calc(100dvh - var(--topbar-height));
+  height: 100vh;
+  height: 100dvh;
   min-height: 0;
   margin: calc(var(--space-6) * -1);
   overflow: hidden;
   background: var(--color-bg);
+}
+
+.workspace-topbar + .content .chat-fullscreen {
+  height: calc(100vh - var(--topbar-height));
+  height: calc(100dvh - var(--topbar-height));
 }
 
 /* ---------- Top Bar ---------- */


### PR DESCRIPTION
### Motivation
- Assistant full-screen chat could show an unwanted blank area at the bottom when the workspace topbar is not rendered, causing visual layout issues on the assistant page.

### Description
- Update `src/app/styles/global.css` to make `.chat-fullscreen` occupy the full viewport height by default using `height: 100vh` / `100dvh` and avoid reserving extra bottom space.
- Add a contextual override rule `.workspace-topbar + .content .chat-fullscreen` that restores the previous behavior of subtracting `var(--topbar-height)` when the workspace topbar is present to avoid regressions.
- Change is limited to CSS and intended to only affect the assistant full-screen layout; a verification screenshot was captured at `artifacts/assistant-no-bottom-gap.png` to confirm the blank area is gone.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run test` and all unit tests passed (52 tests, 21 files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699304addfe4832896b804afbcd0e04f)