### PR TITLE
feat(transactions): 增加账单详情第一页/最后一页翻页与当前页汇总行

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -1425,6 +1425,23 @@ tr:hover td {
   width: auto;
 }
 
+.transaction-summary-row td {
+  background: color-mix(in srgb, var(--color-bg-subtle) 75%, white);
+  border-top: 1px solid var(--color-border);
+  font-size: var(--font-sm);
+  color: var(--color-text-secondary);
+}
+
+.transaction-summary-row .transaction-summary-label {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.transaction-summary-row .transaction-summary-amount {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
 @media (max-width: 768px) {
   .transaction-pagination,
   .transaction-pagination-controls {

--- a/src/features/transactions/components/TransactionTable.test.tsx
+++ b/src/features/transactions/components/TransactionTable.test.tsx
@@ -36,8 +36,10 @@ describe('TransactionTable', () => {
         }}
         onRetry={vi.fn()}
         onClearFilters={vi.fn()}
+        onFirstPage={vi.fn()}
         onPrevPage={vi.fn()}
         onNextPage={vi.fn()}
+        onLastPage={vi.fn()}
         onPageSizeChange={vi.fn()}
         onOpenDetail={vi.fn()}
         onDelete={vi.fn()}
@@ -134,8 +136,10 @@ describe('TransactionTable', () => {
         }}
         onRetry={vi.fn()}
         onClearFilters={vi.fn()}
+        onFirstPage={vi.fn()}
         onPrevPage={vi.fn()}
         onNextPage={vi.fn()}
+        onLastPage={vi.fn()}
         onPageSizeChange={vi.fn()}
         onOpenDetail={vi.fn()}
         onDelete={vi.fn()}
@@ -179,5 +183,118 @@ describe('TransactionTable', () => {
 
     const aiButton = screen.getByRole('button', { name: '⏹ 停止 AI 重分类' });
     expect(aiButton).toBeEnabled();
+  });
+
+  it('展示分页首尾按钮与当前页汇总行', () => {
+    render(
+      <TransactionTable
+        rows={[
+          {
+            item: {
+              id: 'tx-income',
+              date: '2026-03-10',
+              type: 'income',
+              categoryId: 'cat-1',
+              accountId: 'acc-1',
+              amount: 200,
+              note: '工资',
+              tags: []
+            },
+            categoryName: '收入',
+            accountName: '银行卡'
+          },
+          {
+            item: {
+              id: 'tx-expense',
+              date: '2026-03-11',
+              type: 'expense',
+              categoryId: 'cat-2',
+              accountId: 'acc-1',
+              amount: 50,
+              note: '午餐',
+              tags: []
+            },
+            categoryName: '餐饮',
+            accountName: '银行卡'
+          }
+        ]}
+        total={2}
+        filteredTotal={2}
+        page={2}
+        pages={3}
+        pageSize={8}
+        pageSizeOptions={[8, 20]}
+        loading={false}
+        hasFilters
+        selectedIds={[]}
+        bulkSelectionEnabled={false}
+        canSelectAllOnPage={false}
+        allPageSelected={false}
+        sortKey="date"
+        sortDirection="desc"
+        quickFilters={{
+          date: '',
+          type: 'all',
+          category: '',
+          account: '',
+          amountMin: '',
+          amountMax: '',
+          tags: '',
+          merchant: '',
+          orderNo: '',
+          merchantOrderNo: '',
+          note: ''
+        }}
+        onRetry={vi.fn()}
+        onClearFilters={vi.fn()}
+        onFirstPage={vi.fn()}
+        onPrevPage={vi.fn()}
+        onNextPage={vi.fn()}
+        onLastPage={vi.fn()}
+        onPageSizeChange={vi.fn()}
+        onOpenDetail={vi.fn()}
+        onDelete={vi.fn()}
+        onDeleteSelected={vi.fn()}
+        onBulkEditCategory={vi.fn()}
+        onBulkAiRecategorize={vi.fn()}
+        bulkAiRecategorizing={false}
+        onBulkEditAccount={vi.fn()}
+        categoryOptions={[]}
+        accountOptions={[]}
+        onClearSelection={vi.fn()}
+        onToggleSelect={vi.fn()}
+        onToggleSelectPage={vi.fn()}
+        onSortChange={vi.fn()}
+        onQuickFilterChange={vi.fn()}
+        visibleColumns={{
+          date: true,
+          type: true,
+          category: true,
+          account: true,
+          amount: true,
+          orderNo: true,
+          merchantOrderNo: true,
+          note: true
+        }}
+        columnOrder={[
+          'date',
+          'type',
+          'category',
+          'account',
+          'amount',
+          'orderNo',
+          'merchantOrderNo',
+          'note'
+        ]}
+        onColumnReorder={vi.fn()}
+        columnWidths={{}}
+        onColumnResize={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: '第一页' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '最后一页' })).toBeInTheDocument();
+    expect(screen.getByText('汇总（当前页 2 条）')).toBeInTheDocument();
+    expect(screen.getByText(/金额合计 ¥250.00/)).toBeInTheDocument();
   });
 });

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { TransactionItem } from '../../../entities/transaction/types';
 import { EMPTY_CATEGORY_FILTER_VALUE } from '../model/categoryQuickFilter';
@@ -91,6 +91,8 @@ interface TransactionTableProps {
   onClearFilters: () => void;
   onPrevPage: () => void;
   onNextPage: () => void;
+  onFirstPage: () => void;
+  onLastPage: () => void;
   onPageSizeChange: (size: number) => void;
   onOpenDetail: (id: string) => void;
   onDelete: (id: string) => void;
@@ -141,6 +143,8 @@ export function TransactionTable({
   onClearFilters,
   onPrevPage,
   onNextPage,
+  onFirstPage,
+  onLastPage,
   onPageSizeChange,
   onOpenDetail,
   onDelete,
@@ -238,6 +242,23 @@ export function TransactionTable({
     merchantOrderNo: 'merchantOrderNo',
     note: 'note'
   };
+
+  const pageSummary = useMemo(() => {
+    const incomeTotal = rows.reduce(
+      (sum, row) => (row.item.type === 'income' ? sum + row.item.amount : sum),
+      0
+    );
+    const expenseTotal = rows.reduce(
+      (sum, row) => (row.item.type !== 'income' ? sum + row.item.amount : sum),
+      0
+    );
+    return {
+      incomeTotal,
+      expenseTotal,
+      netTotal: incomeTotal - expenseTotal,
+      overallTotal: rows.reduce((sum, row) => sum + row.item.amount, 0)
+    };
+  }, [rows]);
 
   useEffect(() => {
     const handleMouseMove = (event: MouseEvent) => {
@@ -670,6 +691,42 @@ export function TransactionTable({
                   })
                 )}
               </tbody>
+              {rows.length > 0 && (
+                <tfoot>
+                  <tr className="transaction-summary-row">
+                    {bulkSelectionEnabled ? (
+                      <td className="transaction-summary-label">汇总</td>
+                    ) : null}
+                    {orderedColumns
+                      .filter((column) => visibleColumns[column.key])
+                      .map((column, index) => {
+                        const isFirstVisible = index === 0;
+                        if (column.key === 'amount') {
+                          return (
+                            <td
+                              key={`summary-${column.key}`}
+                              className="transaction-summary-amount"
+                            >
+                              金额合计 {formatCurrency(pageSummary.overallTotal)} ｜ 收入{' '}
+                              {formatCurrency(pageSummary.incomeTotal)} ｜ 支出{' '}
+                              {formatCurrency(pageSummary.expenseTotal)} ｜ 净额{' '}
+                              {formatCurrency(pageSummary.netTotal)}
+                            </td>
+                          );
+                        }
+
+                        return (
+                          <td
+                            key={`summary-${column.key}`}
+                            className={isFirstVisible ? 'transaction-summary-label' : undefined}
+                          >
+                            {isFirstVisible ? `汇总（当前页 ${rows.length} 条）` : '-'}
+                          </td>
+                        );
+                      })}
+                  </tr>
+                </tfoot>
+              )}
             </table>
           </div>
 
@@ -771,6 +828,9 @@ export function TransactionTable({
                   ))}
                 </select>
               </label>
+              <button type="button" disabled={page === 1} onClick={onFirstPage}>
+                第一页
+              </button>
               <button type="button" disabled={page === 1} onClick={onPrevPage}>
                 上一页
               </button>
@@ -779,6 +839,9 @@ export function TransactionTable({
               </small>
               <button type="button" disabled={page === pages} onClick={onNextPage}>
                 下一页
+              </button>
+              <button type="button" disabled={page === pages} onClick={onLastPage}>
+                最后一页
               </button>
             </div>
           </div>

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -1215,8 +1215,10 @@ export function TransactionsPage() {
         quickFilters={quickFilters}
         onSortChange={handleSortChange}
         onQuickFilterChange={handleQuickFilterChange}
+        onFirstPage={() => setPage(1)}
         onPrevPage={() => setPage(Math.max(1, page - 1))}
         onNextPage={() => setPage(Math.min(pages, page + 1))}
+        onLastPage={() => setPage(pages)}
         onPageSizeChange={(size) => {
           // 切换页大小后重置到第一页，避免超页码导致用户误解“数据丢失”。
           setPageSize(size);


### PR DESCRIPTION
### Motivation
- 提升账单详情的翻页可用性，支持快速跳转到首尾页以便定位历史/最新记录。 
- 在表格底部增加类似 Excel 的汇总行以便直接查看当前页的金额合计和收支汇总。 

### Description
- 为 `TransactionTable` 添加 `onFirstPage` 与 `onLastPage` 回调并在分页区新增“第一页 / 最后一页”按钮以支持首尾跳转。 
- 在 `TransactionTable` 中通过 `useMemo` 计算当前页可见行的 `incomeTotal`、`expenseTotal`、`overallTotal` 和 `netTotal`，并渲染一个 `<tfoot>` 汇总行展示这些数据。 
- 在 `TransactionsPage` 中接入上述回调（`setPage(1)` / `setPage(pages)`）。 
- 新增样式到 `src/app/styles/global.css` 以区分汇总行视觉样式，并更新 `TransactionTable` 组件测试用例以覆盖新分页回调与汇总行渲染。 
- 变更文件：`src/features/transactions/components/TransactionTable.tsx`、`src/pages/transactions/TransactionsPage.tsx`、`src/app/styles/global.css`、`src/features/transactions/components/TransactionTable.test.tsx`。 

### Testing
- 运行单元测试 `npm run test -- src/features/transactions/components/TransactionTable.test.tsx`，测试结果：3 个测试全部通过。 
- 执行构建 `npm run build`，结果：构建成功且产物生成完成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993304591d88328b8e621934b8693f6)