### PR TITLE
Improve transaction table resize affordance and add status column

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -1134,18 +1134,40 @@ tr:hover td {
 }
 
 .transaction-table-wrap thead th:not(.transaction-select-col) {
-  position: sticky;
+  position: relative;
 }
 
 .transaction-col-resizer {
   position: absolute;
   top: 0;
-  right: -5px;
-  width: 10px;
+  right: -6px;
+  width: 12px;
   height: 100%;
   cursor: col-resize;
   user-select: none;
   z-index: 2;
+}
+
+.transaction-col-resizer::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-primary) 36%, var(--color-border));
+  transform: translateX(-50%);
+  opacity: 0.7;
+  transition:
+    opacity var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.transaction-table-wrap thead th:hover .transaction-col-resizer::before,
+.transaction-table-wrap thead th:focus-within .transaction-col-resizer::before {
+  opacity: 1;
+  background: var(--color-primary);
 }
 
 .transaction-action-col {

--- a/src/features/transactions/components/TransactionFilters.test.tsx
+++ b/src/features/transactions/components/TransactionFilters.test.tsx
@@ -34,6 +34,7 @@ describe('TransactionFilters', () => {
           visibleColumns={{
             date: true,
             type: true,
+            status: true,
             category: true,
             account: true,
             amount: true,

--- a/src/features/transactions/components/TransactionTable.test.tsx
+++ b/src/features/transactions/components/TransactionTable.test.tsx
@@ -24,6 +24,7 @@ describe('TransactionTable', () => {
         quickFilters={{
           date: '',
           type: 'all',
+          status: 'all',
           category: '',
           account: '',
           amountMin: '',
@@ -56,6 +57,7 @@ describe('TransactionTable', () => {
         visibleColumns={{
           date: true,
           type: true,
+          status: true,
           category: true,
           account: true,
           amount: true,
@@ -66,6 +68,7 @@ describe('TransactionTable', () => {
         columnOrder={[
           'date',
           'type',
+          'status',
           'category',
           'account',
           'amount',
@@ -122,6 +125,7 @@ describe('TransactionTable', () => {
         quickFilters={{
           date: '',
           type: 'all',
+          status: 'all',
           category: '',
           account: '',
           amountMin: '',
@@ -154,6 +158,7 @@ describe('TransactionTable', () => {
         visibleColumns={{
           date: true,
           type: true,
+          status: true,
           category: true,
           account: true,
           amount: true,
@@ -164,6 +169,7 @@ describe('TransactionTable', () => {
         columnOrder={[
           'date',
           'type',
+          'status',
           'category',
           'account',
           'amount',

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { TransactionItem } from '../../../entities/transaction/types';
+import { TransactionItem, TransactionStatus } from '../../../entities/transaction/types';
 import { EMPTY_CATEGORY_FILTER_VALUE } from '../model/categoryQuickFilter';
 import { formatCurrency, formatDate } from '../../../shared/lib/format';
 import { EmptyState } from '../../../shared/ui/EmptyState';
@@ -11,6 +11,7 @@ const NOTE_MAX_LENGTH = 22;
 export type TransactionSortKey =
   | 'date'
   | 'type'
+  | 'status'
   | 'category'
   | 'account'
   | 'amount'
@@ -22,6 +23,7 @@ export type TransactionSortDirection = 'asc' | 'desc';
 export interface TransactionQuickFilters {
   date: string;
   type: 'all' | 'income' | 'expense' | 'budget' | 'repayment';
+  status: 'all' | TransactionStatus;
   category: string;
   account: string;
   amountMin: string;
@@ -58,9 +60,23 @@ export interface TransactionRowView {
   accountName: string;
 }
 
+const STATUS_LABELS: Record<TransactionStatus, string> = {
+  pending: '待处理',
+  completed: '已完成',
+  refunded: '已退款',
+  closed: '已关闭',
+  failed: '失败'
+};
+
+function formatStatus(status?: TransactionStatus): string {
+  if (!status) return '-';
+  return STATUS_LABELS[status] || status;
+}
+
 export type TransactionColumnKey =
   | 'date'
   | 'type'
+  | 'status'
   | 'category'
   | 'account'
   | 'amount'
@@ -181,6 +197,7 @@ export function TransactionTable({
   const columnOptions: Array<{ key: TransactionColumnKey; label: string }> = [
     { key: 'date', label: '日期' },
     { key: 'type', label: '类型' },
+    { key: 'status', label: '交易状态' },
     { key: 'category', label: '分类' },
     { key: 'account', label: '账户' },
     { key: 'amount', label: '金额' },
@@ -211,6 +228,8 @@ export function TransactionTable({
               : '支出';
       case 'category':
         return categoryName;
+      case 'status':
+        return formatStatus(item.status);
       case 'account':
         return accountName;
       case 'amount':
@@ -227,8 +246,8 @@ export function TransactionTable({
   };
 
   const textFilterKeyMap: Record<
-    Exclude<TransactionColumnKey, 'type'>,
-    Exclude<keyof TransactionQuickFilters, 'type'>
+    Exclude<TransactionColumnKey, 'type' | 'status'>,
+    Exclude<keyof TransactionQuickFilters, 'type' | 'status'>
   > = {
     date: 'date',
     category: 'category',
@@ -462,24 +481,42 @@ export function TransactionTable({
                   {bulkSelectionEnabled ? <th className="transaction-select-col" /> : null}
                   {orderedColumns.map((column) => {
                     if (!visibleColumns[column.key]) return null;
-                    if (column.key === 'type') {
+                    if (column.key === 'type' || column.key === 'status') {
                       return (
                         <th key={`filter-${column.key}`}>
                           <select
-                            aria-label="按类型筛选"
-                            value={quickFilters.type}
+                            aria-label={column.key === 'type' ? '按类型筛选' : '按交易状态筛选'}
+                            value={column.key === 'type' ? quickFilters.type : quickFilters.status}
                             onChange={(event) =>
-                              onQuickFilterChange(
-                                'type',
-                                event.target.value as TransactionQuickFilters['type']
-                              )
+                              column.key === 'type'
+                                ? onQuickFilterChange(
+                                    'type',
+                                    event.target.value as TransactionQuickFilters['type']
+                                  )
+                                : onQuickFilterChange(
+                                    'status',
+                                    event.target.value as TransactionQuickFilters['status']
+                                  )
                             }
                           >
-                            <option value="all">全部</option>
-                            <option value="income">收入</option>
-                            <option value="expense">支出</option>
-                            <option value="budget">预算</option>
-                            <option value="repayment">还款</option>
+                            {column.key === 'type' ? (
+                              <>
+                                <option value="all">全部</option>
+                                <option value="income">收入</option>
+                                <option value="expense">支出</option>
+                                <option value="budget">预算</option>
+                                <option value="repayment">还款</option>
+                              </>
+                            ) : (
+                              <>
+                                <option value="all">全部</option>
+                                <option value="pending">待处理</option>
+                                <option value="completed">已完成</option>
+                                <option value="refunded">已退款</option>
+                                <option value="closed">已关闭</option>
+                                <option value="failed">失败</option>
+                              </>
+                            )}
                           </select>
                         </th>
                       );
@@ -536,14 +573,14 @@ export function TransactionTable({
                             value={
                               quickFilters[
                                 textFilterKeyMap[
-                                  column.key as Exclude<TransactionColumnKey, 'type'>
+                                  column.key as Exclude<TransactionColumnKey, 'type' | 'status'>
                                 ]
                               ]
                             }
                             onChange={(event) => {
                               const filterKey =
                                 textFilterKeyMap[
-                                  column.key as Exclude<TransactionColumnKey, 'type'>
+                                  column.key as Exclude<TransactionColumnKey, 'type' | 'status'>
                                 ];
                               onQuickFilterChange(filterKey, event.target.value);
                             }}

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -43,6 +43,7 @@ type BillSource = 'wechat' | 'alipay';
 const DEFAULT_QUICK_FILTERS: TransactionQuickFilters = {
   date: '',
   type: 'all',
+  status: 'all',
   category: '',
   account: '',
   amountMin: '',
@@ -57,6 +58,7 @@ const DEFAULT_QUICK_FILTERS: TransactionQuickFilters = {
 const DEFAULT_VISIBLE_COLUMNS: Record<TransactionColumnKey, boolean> = {
   date: true,
   type: true,
+  status: true,
   category: true,
   account: true,
   amount: true,
@@ -68,6 +70,7 @@ const DEFAULT_VISIBLE_COLUMNS: Record<TransactionColumnKey, boolean> = {
 const DEFAULT_COLUMN_ORDER: TransactionColumnKey[] = [
   'date',
   'type',
+  'status',
   'category',
   'account',
   'amount',
@@ -79,6 +82,7 @@ const DEFAULT_COLUMN_ORDER: TransactionColumnKey[] = [
 const COLUMN_OPTIONS: Array<{ key: TransactionColumnKey; label: string }> = [
   { key: 'date', label: '日期' },
   { key: 'type', label: '类型' },
+  { key: 'status', label: '交易状态' },
   { key: 'category', label: '分类' },
   { key: 'account', label: '账户' },
   { key: 'amount', label: '金额' },
@@ -495,6 +499,7 @@ export function TransactionsPage() {
   const quickFilteredRows = useMemo(() => {
     const dateFilter = quickFilters.date.trim().toLowerCase();
     const categoryFilter = quickFilters.category.trim();
+    const statusFilter = quickFilters.status;
     const accountFilter = quickFilters.account.trim().toLowerCase();
     const amountMinRaw = quickFilters.amountMin.trim();
     const amountMaxRaw = quickFilters.amountMax.trim();
@@ -516,6 +521,7 @@ export function TransactionsPage() {
     return mappedRows.filter((row) => {
       const dateText = formatDate(row.item.date).toLowerCase();
       const typePass = quickFilters.type === 'all' ? true : row.item.type === quickFilters.type;
+      const statusPass = statusFilter === 'all' ? true : row.item.status === statusFilter;
       const categoryPass = matchesCategoryQuickFilter(categoryFilter, row.item.categoryId);
       const accountPass = !accountFilter || row.accountName.toLowerCase().includes(accountFilter);
       const orderNoPass =
@@ -537,6 +543,7 @@ export function TransactionsPage() {
       return (
         (!dateFilter || dateText.includes(dateFilter)) &&
         typePass &&
+        statusPass &&
         categoryPass &&
         accountPass &&
         amountPass &&
@@ -560,6 +567,9 @@ export function TransactionsPage() {
           break;
         case 'type':
           compare = a.item.type.localeCompare(b.item.type);
+          break;
+        case 'status':
+          compare = (a.item.status || '').localeCompare(b.item.status || '', 'zh-CN');
           break;
         case 'category':
           compare = a.categoryName.localeCompare(b.categoryName, 'zh-CN');
@@ -982,6 +992,7 @@ export function TransactionsPage() {
   const hasQuickFilters =
     quickFilters.date.trim().length > 0 ||
     quickFilters.type !== 'all' ||
+    quickFilters.status !== 'all' ||
     quickFilters.category.trim().length > 0 ||
     quickFilters.account.trim().length > 0 ||
     quickFilters.amountMin.trim().length > 0 ||


### PR DESCRIPTION
### Motivation
- Make column resize handles easier to target and visually clearer because the thin separator was hard to hit with the mouse. 
- Expose transaction `status` as a visible, sortable and filterable column because the table lacked a dedicated transaction status column.

### Description
- Widen the column resizer hit area and add a visible divider line with hover/focus emphasis in `src/app/styles/global.css` to improve affordance for dragging (`.transaction-col-resizer` + `::before`).
- Add a `status` column to the table by extending `TransactionColumnKey`, `TransactionQuickFilters`, `columnOptions`, render logic and labels in `src/features/transactions/components/TransactionTable.tsx`, including localized status labels and a `formatStatus` helper.
- Wire status into the data pipeline by adding default `status` quick filter, visibility and column order entries and implementing status filtering and sorting in `src/pages/transactions/TransactionsPage.tsx`.
- Update unit test fixtures to include `status` and the new column in `TransactionTable.test.tsx` and `TransactionFilters.test.tsx` to satisfy TypeScript types and keep tests accurate.

### Testing
- Ran `npm run lint` and the linter completed successfully.
- Ran `npm run build` and the production build finished without errors.
- Ran `npm test` and all tests passed (`21` test files, `53` tests passed) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69932f7407a483288b8c7d95658e1770)