### PR TITLE
fix: add missing `status` in TransactionTable test props

### DIFF
--- a/src/features/transactions/components/TransactionTable.test.tsx
+++ b/src/features/transactions/components/TransactionTable.test.tsx
@@ -241,6 +241,7 @@ describe('TransactionTable', () => {
         quickFilters={{
           date: '',
           type: 'all',
+          status: 'all',
           category: '',
           account: '',
           amountMin: '',
@@ -275,6 +276,7 @@ describe('TransactionTable', () => {
         visibleColumns={{
           date: true,
           type: true,
+          status: true,
           category: true,
           account: true,
           amount: true,
@@ -285,6 +287,7 @@ describe('TransactionTable', () => {
         columnOrder={[
           'date',
           'type',
+          'status',
           'category',
           'account',
           'amount',


### PR DESCRIPTION
### Motivation
- TypeScript build failed due to tests providing props that lacked the required `status` field for `TransactionQuickFilters`, causing `TS2741` in `TransactionTable.test.tsx`.

### Description
- Added `status: 'all'` to `quickFilters`, `status: true` to `visibleColumns`, and `'status'` to `columnOrder` in `src/features/transactions/components/TransactionTable.test.tsx` to align the test props with `TransactionQuickFilters` and `TransactionColumnKey` types.

### Testing
- Ran `npm run build` (which runs `tsc --noEmit` and `vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699332cd0fc88328a75adfa19478addb)