### PR TITLE
优化交易记录表头对齐并修复金额列收缩问题

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -956,6 +956,14 @@ tr:hover td {
   font-weight: inherit;
 }
 
+.transaction-sort-btn-center {
+  justify-content: center;
+}
+
+.transaction-sort-btn-left {
+  justify-content: flex-start;
+}
+
 .transaction-sort-btn:hover:not(:disabled) {
   background: transparent;
   color: var(--color-text);
@@ -969,6 +977,7 @@ tr:hover td {
   border-bottom: 1px solid var(--color-border-light);
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
+  white-space: normal;
 }
 
 .transaction-filter-row input,
@@ -983,15 +992,24 @@ tr:hover td {
 }
 
 .transaction-amount-range-inputs {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   gap: 4px;
+  width: 100%;
 }
 
 .transaction-amount-range-inputs input {
   min-width: 0;
-  width: auto;
-  flex: 1 1 0;
+  width: 100%;
+}
+
+.transaction-table-wrap thead th.transaction-col-compact {
+  text-align: center;
+}
+
+.transaction-table-wrap thead th.transaction-col-long-text {
+  text-align: left;
 }
 
 .transaction-context-menu {

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -14,6 +14,10 @@ function getMinColumnWidth(key: TransactionColumnKey): number {
   return key === 'amount' ? AMOUNT_COLUMN_MIN_WIDTH : DEFAULT_MIN_COLUMN_WIDTH;
 }
 
+function isLongTextColumn(key: TransactionColumnKey): boolean {
+  return key === 'orderNo' || key === 'merchantOrderNo' || key === 'note';
+}
+
 export type TransactionSortKey =
   | 'date'
   | 'type'
@@ -459,7 +463,11 @@ export function TransactionTable({
                     return (
                       <th
                         key={`head-${column.key}`}
-                        className={`transaction-col-${column.key}`}
+                        className={`transaction-col-${column.key} ${
+                          isLongTextColumn(column.key)
+                            ? 'transaction-col-long-text'
+                            : 'transaction-col-compact'
+                        }`}
                         draggable
                         onDragStart={() => {
                           dragColumnRef.current = column.key;
@@ -474,7 +482,11 @@ export function TransactionTable({
                       >
                         <button
                           type="button"
-                          className={`transaction-sort-btn ${sortKey === column.key ? 'active' : ''}`}
+                          className={`transaction-sort-btn ${
+                            isLongTextColumn(column.key)
+                              ? 'transaction-sort-btn-left'
+                              : 'transaction-sort-btn-center'
+                          } ${sortKey === column.key ? 'active' : ''}`}
                           onClick={() => onSortChange(column.key)}
                         >
                           {column.label}{' '}


### PR DESCRIPTION
### Motivation
- 改善交易列表表头的视觉对齐：除了备注/长文本类列之外，其余列应与下方内容视觉居中对齐以提升可读性。 
- 修复金额列在调整列宽后无法向内收紧的问题，该问题由筛选行内控件的最小宽度限制触发。

### Description
- 在 `src/features/transactions/components/TransactionTable.tsx` 添加 `isLongTextColumn` 判断并在表头渲染时为长文本列（`note`、`orderNo`、`merchantOrderNo`）与其他列分别应用不同的 class。 
- 为排序按钮引入 `transaction-sort-btn-center` 与 `transaction-sort-btn-left` 两个样式，以便对齐不同类型列的表头文本。 
- 在 `src/app/styles/global.css` 中将 `.transaction-filter-row th` 的 `white-space` 放宽为 `normal`，并将 `.transaction-amount-range-inputs` 从 `flex` 改为 `grid`（使用 `minmax(0, 1fr) auto minmax(0, 1fr)` 布局）以避免筛选控件撑大列宽。 
- 新增 `.transaction-table-wrap thead th.transaction-col-compact` 与 `.transaction-table-wrap thead th.transaction-col-long-text` 用于分别设置表头居中或左对齐的表现。 

### Testing
- 运行了 `npm run lint`，自动修复与格式化步骤通过（结果：成功）。
- 执行 `npm run build` 进行类型检查与生产打包（Vite 构建），构建成功且无报错。 
- 本地启动开发服务器（`npm run dev`）并使用 Playwright 打开 `/transactions` 页面截图验证视觉效果（截图已生成），交互与显示正常。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699335df64948328a5bec913a2505947)