### PR TITLE
优化交易金额列宽度并精简金额筛选输入

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -991,19 +991,6 @@ tr:hover td {
   background: var(--color-bg-elevated);
 }
 
-.transaction-amount-range-inputs {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-  align-items: center;
-  gap: 4px;
-  width: 100%;
-}
-
-.transaction-amount-range-inputs input {
-  min-width: 0;
-  width: 100%;
-}
-
 .transaction-table-wrap thead th.transaction-col-compact {
   text-align: center;
 }
@@ -1154,7 +1141,8 @@ tr:hover td {
 }
 
 .transaction-table-wrap thead th.transaction-col-amount {
-  min-width: 72px;
+  min-width: 64px;
+  max-width: 108px;
 }
 
 .transaction-table-wrap thead th:not(.transaction-select-col) {

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -8,7 +8,7 @@ import { TableSkeleton } from '../../../shared/ui/TableSkeleton';
 
 const NOTE_MAX_LENGTH = 22;
 const DEFAULT_MIN_COLUMN_WIDTH = 90;
-const AMOUNT_COLUMN_MIN_WIDTH = 72;
+const AMOUNT_COLUMN_MIN_WIDTH = 64;
 
 function getMinColumnWidth(key: TransactionColumnKey): number {
   return key === 'amount' ? AMOUNT_COLUMN_MIN_WIDTH : DEFAULT_MIN_COLUMN_WIDTH;
@@ -595,25 +595,17 @@ export function TransactionTable({
                             ))}
                           </select>
                         ) : column.key === 'amount' ? (
-                          <div className="transaction-amount-range-inputs">
-                            <input
-                              type="number"
-                              value={quickFilters.amountMin}
-                              onChange={(event) =>
-                                onQuickFilterChange('amountMin', event.target.value)
+                          <input
+                            type="number"
+                            value={quickFilters.amountMin}
+                            onChange={(event) => {
+                              onQuickFilterChange('amountMin', event.target.value);
+                              if (quickFilters.amountMax) {
+                                onQuickFilterChange('amountMax', '');
                               }
-                              placeholder="最小"
-                            />
-                            <span>~</span>
-                            <input
-                              type="number"
-                              value={quickFilters.amountMax}
-                              onChange={(event) =>
-                                onQuickFilterChange('amountMax', event.target.value)
-                              }
-                              placeholder="最大"
-                            />
-                          </div>
+                            }}
+                            placeholder="最小金额"
+                          />
                         ) : (
                           <input
                             value={

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -516,16 +516,13 @@ export function TransactionsPage() {
     const statusFilter = quickFilters.status;
     const accountFilter = quickFilters.account.trim().toLowerCase();
     const amountMinRaw = quickFilters.amountMin.trim();
-    const amountMaxRaw = quickFilters.amountMax.trim();
     const amountMin = Number(amountMinRaw);
-    const amountMax = Number(amountMaxRaw);
     /**
      * 根因说明：
      * Number('') === 0，之前在“金额筛选框留空”时被误判为有效条件，
      * 导致列表隐式追加“金额必须等于 0”，于是出现“交易记录为空”。
      */
     const hasAmountMin = amountMinRaw.length > 0 && Number.isFinite(amountMin);
-    const hasAmountMax = amountMaxRaw.length > 0 && Number.isFinite(amountMax);
     const tagsFilter = quickFilters.tags.trim().toLowerCase();
     const merchantFilter = quickFilters.merchant.trim().toLowerCase();
     const orderNoFilter = quickFilters.orderNo.trim().toLowerCase();
@@ -550,9 +547,7 @@ export function TransactionsPage() {
         (row.item.note || '').toLowerCase().includes(merchantFilter) ||
         (row.item.merchantOrderNo || '').toLowerCase().includes(merchantFilter);
       const notePass = !noteFilter || (row.item.note || '').toLowerCase().includes(noteFilter);
-      const amountPass =
-        (!hasAmountMin || row.item.amount >= amountMin) &&
-        (!hasAmountMax || row.item.amount <= amountMax);
+      const amountPass = !hasAmountMin || row.item.amount >= amountMin;
 
       return (
         (!dateFilter || dateText.includes(dateFilter)) &&
@@ -1010,7 +1005,6 @@ export function TransactionsPage() {
     quickFilters.category.trim().length > 0 ||
     quickFilters.account.trim().length > 0 ||
     quickFilters.amountMin.trim().length > 0 ||
-    quickFilters.amountMax.trim().length > 0 ||
     quickFilters.tags.trim().length > 0 ||
     quickFilters.merchant.trim().length > 0 ||
     quickFilters.orderNo.trim().length > 0 ||


### PR DESCRIPTION
### Motivation

- 缩减金额列横向占用并释放筛选行空间以解决“金额列太宽”与“筛选行过长”的视觉和交互问题。 
- 简化金额筛选为单一输入以满足“且不需要两个筛选框”的需求并避免空输入被误判的问题。 

### Description

- 将金额列最小宽度从 `72` 调整为 `64`，并在样式中为金额列新增 `max-width: 108px`，修改文件 `src/app/styles/global.css`。 
- 在表格筛选行中把金额的“双输入（amountMin / amountMax）”替换为单一的最小金额输入，并在输入变化时清理遗留的 `amountMax`，修改文件 `src/features/transactions/components/TransactionTable.tsx`。 
- 同步精简交易页快速筛选逻辑：移除对 `amountMax` 的解析与判断，过滤条件仅使用 `amountMin`，并从“是否存在快速筛选”判断中移除 `amountMax`，修改文件 `src/pages/transactions/TransactionsPage.tsx`。 

### Testing

- 运行单元测试 `npm test -- --run src/features/transactions/components/TransactionTable.test.tsx`，结果通过（3 个测试通过）。 
- 运行 `npm run build`，构建成功。 
- 运行 `npm run lint`，静态校验通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993affff870832882cc920fa69c69c9)