### PR TITLE
fix: allow transaction amount column to shrink to content

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -1161,7 +1161,7 @@ tr:hover td {
 
 .transaction-table-wrap table {
   font-size: clamp(13px, 0.88vw, 14px);
-  min-width: 100%;
+  min-width: max-content;
   width: max-content;
 }
 


### PR DESCRIPTION
### Motivation
- The transactions table was forcing a full-width layout (`min-width: 100%`) which caused compact columns like the `金额` (amount) column to be stretched wider than their content, so the table should size to its content to allow such columns to shrink.

### Description
- Change `min-width` for `.transaction-table-wrap table` from `100%` to `max-content` in `src/app/styles/global.css` so the table follows content width instead of forcing full-width.

### Testing
- Ran `npm run lint` which passed, and ran an automated Playwright script that loaded `/transactions` and captured a screenshot to verify the table layout change; both steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b7b01a248328ab815008383aeee0)