### PR TITLE
feat: smart budget — editable recommendations, health explanation, trends & anomaly alerts

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -6257,6 +6257,14 @@ body.exchange-resizing {
   color: var(--color-text);
 }
 
+.smart-budget-health-explain {
+  margin: 0;
+  font-size: var(--font-xs);
+  color: var(--color-text-tertiary);
+  max-width: 420px;
+  text-align: center;
+}
+
 .smart-budget-management-topbar {
   display: flex;
   gap: var(--space-3);
@@ -6510,6 +6518,24 @@ body.exchange-resizing {
   overflow: hidden;
 }
 
+.smart-budget-table input[type='number'] {
+  width: 100%;
+  min-width: 120px;
+}
+
+.smart-budget-delta {
+  margin: var(--space-3) 0 0;
+  font-size: var(--font-sm);
+}
+
+.smart-budget-delta.balanced {
+  color: var(--color-success);
+}
+
+.smart-budget-delta.unbalanced {
+  color: var(--color-danger);
+}
+
 .smart-budget-actions {
   display: flex;
   flex-wrap: wrap;
@@ -6608,6 +6634,66 @@ body.exchange-resizing {
 .smart-budget-ai-tags .ai-tag.increase {
   color: var(--color-success);
   border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border));
+}
+
+.smart-budget-trend-card,
+.smart-budget-anomaly-card {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: var(--color-bg-elevated);
+}
+
+.smart-budget-trend-card h4,
+.smart-budget-anomaly-card h4 {
+  margin: 0 0 var(--space-3);
+}
+
+.smart-budget-trend-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-3);
+}
+
+.smart-budget-trend-item {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.smart-budget-trend-item header {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-sm);
+}
+
+.smart-budget-trend-bars {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 6px;
+  align-items: end;
+  min-height: 86px;
+}
+
+.smart-budget-trend-bars div {
+  height: 86px;
+  display: flex;
+  align-items: end;
+}
+
+.smart-budget-trend-bars span {
+  width: 100%;
+  min-height: 2px;
+  border-radius: 8px 8px 4px 4px;
+  background: color-mix(in srgb, var(--color-primary) 70%, #fff);
+}
+
+.smart-budget-anomaly-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.smart-budget-anomaly-card li + li {
+  margin-top: var(--space-2);
 }
 
 .smart-budget-detail-drawer {

--- a/src/features/smart-budget/model/budgetPlanner.test.ts
+++ b/src/features/smart-budget/model/budgetPlanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateBudgetRecommendation } from './budgetPlanner';
+import { applyCategoryBudgetEdits, generateBudgetRecommendation } from './budgetPlanner';
 
 describe('generateBudgetRecommendation', () => {
   it('should keep total category budgets equal to monthly income', () => {
@@ -35,5 +35,22 @@ describe('generateBudgetRecommendation', () => {
         savingsRatio: 0.3
       })
     ).toThrow('固定支出需要小于月收入，才能生成可执行预算。');
+  });
+
+  it('supports quick category budget edits on result page', () => {
+    const result = generateBudgetRecommendation({
+      identity: 'employee',
+      monthlyIncomeK: 10,
+      monthlyFixedExpenseK: 3,
+      savingsRatio: 0.3
+    });
+
+    const edited = applyCategoryBudgetEdits(result, {
+      餐饮: 1800,
+      '储蓄/投资': 2400
+    });
+
+    expect(edited.categoryBudgets.find((item) => item.category === '餐饮')?.amount).toBe(1800);
+    expect(edited.savingsAmount).toBe(2400);
   });
 });

--- a/src/features/smart-budget/model/budgetPlanner.ts
+++ b/src/features/smart-budget/model/budgetPlanner.ts
@@ -22,6 +22,42 @@ export type BudgetRecommendation = {
   categoryBudgets: BudgetCategoryPlan[];
 };
 
+export function applyCategoryBudgetEdits(
+  recommendation: BudgetRecommendation,
+  updates: Record<string, number>
+): BudgetRecommendation {
+  const monthlyIncome = recommendation.monthlyIncome;
+  const editedCategoryBudgets = recommendation.categoryBudgets.map((item) => {
+    const nextAmount = updates[item.category];
+    const amount =
+      Number.isFinite(nextAmount) && nextAmount >= 0
+        ? Math.round(nextAmount)
+        : Math.round(item.amount);
+    return {
+      ...item,
+      amount,
+      ratio: monthlyIncome > 0 ? amount / monthlyIncome : 0
+    };
+  });
+
+  const monthlyFixedExpense =
+    editedCategoryBudgets.find((item) => item.category === '固定支出')?.amount || 0;
+  const savingsAmount =
+    editedCategoryBudgets.find((item) => item.category === '储蓄/投资')?.amount || 0;
+  const flexibleBudget = editedCategoryBudgets
+    .filter((item) => !['固定支出', '储蓄/投资'].includes(item.category))
+    .reduce((sum, item) => sum + item.amount, 0);
+
+  return {
+    ...recommendation,
+    monthlyFixedExpense,
+    savingsAmount,
+    flexibleBudget,
+    disposableIncome: monthlyIncome - monthlyFixedExpense,
+    categoryBudgets: editedCategoryBudgets
+  };
+}
+
 const IDENTITY_LABELS: Record<UserIdentity, string> = {
   student: '学生',
   employee: '上班族',

--- a/src/pages/smart-budget/SmartBudgetPage.tsx
+++ b/src/pages/smart-budget/SmartBudgetPage.tsx
@@ -6,6 +6,7 @@ import {
   BudgetAnswers,
   BudgetRecommendation,
   UserIdentity,
+  applyCategoryBudgetEdits,
   generateBudgetRecommendation,
   getIdentityLabel
 } from '../../features/smart-budget/model/budgetPlanner';
@@ -92,6 +93,7 @@ export function SmartBudgetPage() {
   const [statusFilter, setStatusFilter] = useState<'all' | 'overspent' | 'safe'>('all');
   const [answers, setAnswers] = useState<BudgetAnswers>(initialAnswers);
   const [draftRecommendation, setDraftRecommendation] = useState<BudgetRecommendation | null>(null);
+  const [draftTotalDelta, setDraftTotalDelta] = useState(0);
   const [selectedMonthKey, setSelectedMonthKey] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<BudgetTrackingRow | null>(null);
 
@@ -177,6 +179,90 @@ export function SmartBudgetPage() {
       healthScore
     };
   }, [trackingRows, monthTransactions, overspentCount]);
+
+  const healthExplainText = useMemo(() => {
+    const executionPercent = managementOverview.executionRate * 100;
+    if (executionPercent < 80) return '执行率低于 80%，预算较宽裕，可将结余优先转入储蓄或应急金。';
+    if (executionPercent <= 100) return '执行率在 80%~100% 区间，预算使用健康，建议保持当前节奏。';
+    return '执行率高于 100%，说明已超支，请优先压降非必要支出或调高重点分类预算。';
+  }, [managementOverview.executionRate]);
+
+  const categoryTrendRows = useMemo(() => {
+    if (!confirmedPlan) return [];
+
+    const recentKeys = getRecentMonthOptions(transactions, 6)
+      .map((item) => item.key)
+      .reverse();
+    const monthLabelMap = new Map(
+      getRecentMonthOptions(transactions, 6).map((item) => [item.key, item.label])
+    );
+
+    const trackedCategories = confirmedPlan.recommendation.categoryBudgets
+      .filter((item) => !['固定支出', '储蓄/投资'].includes(item.category))
+      .slice(0, 6);
+
+    const monthRows = recentKeys.map((key) => ({
+      key,
+      rows: buildBudgetTrackingRows({
+        recommendation: confirmedPlan.recommendation,
+        categories,
+        transactions,
+        monthKey: key
+      })
+    }));
+
+    return trackedCategories.map((budget) => ({
+      category: budget.category,
+      points: monthRows.map((month) => {
+        const row = month.rows.find((item) => item.category === budget.category);
+        return {
+          monthKey: month.key,
+          monthLabel: monthLabelMap.get(month.key) || month.key,
+          ratio: row?.ratio || 0
+        };
+      })
+    }));
+  }, [confirmedPlan, transactions, categories]);
+
+  const anomalyAlerts = useMemo(() => {
+    if (!activeMonthKey || !trackingRows.length) return [];
+    const [yearStr, monthStr] = activeMonthKey.split('-');
+    const year = Number(yearStr);
+    const month = Number(monthStr);
+    if (!Number.isFinite(year) || !Number.isFinite(month)) return [];
+
+    const now = new Date();
+    const isCurrentMonth = now.getFullYear() === year && now.getMonth() + 1 === month;
+    const dayPassed = isCurrentMonth
+      ? Math.max(now.getDate(), 1)
+      : new Date(year, month, 0).getDate();
+    const totalDays = new Date(year, month, 0).getDate();
+
+    return trackingRows
+      .map((item) => {
+        const projectedSpent =
+          dayPassed > 0 ? (item.spentAmount / dayPassed) * totalDays : item.spentAmount;
+        const riskRatio = item.budgetAmount > 0 ? projectedSpent / item.budgetAmount : 0;
+        const suggestedSaving = Math.max(projectedSpent - item.budgetAmount, 0);
+        if (riskRatio <= 1) return null;
+        return {
+          ...item,
+          projectedSpent,
+          riskRatio,
+          suggestedSaving
+        };
+      })
+      .filter(
+        (
+          item
+        ): item is BudgetTrackingRow & {
+          projectedSpent: number;
+          riskRatio: number;
+          suggestedSaving: number;
+        } => Boolean(item)
+      )
+      .sort((a, b) => b.riskRatio - a.riskRatio);
+  }, [activeMonthKey, trackingRows]);
 
   const topOverspentItem = useMemo(
     () =>
@@ -334,6 +420,26 @@ export function SmartBudgetPage() {
     categories
   ]);
 
+  useEffect(() => {
+    if (!draftRecommendation) {
+      setDraftTotalDelta(0);
+      return;
+    }
+
+    const total = draftRecommendation.categoryBudgets.reduce((sum, item) => sum + item.amount, 0);
+    setDraftTotalDelta(total - draftRecommendation.monthlyIncome);
+  }, [draftRecommendation]);
+
+  const handleDraftCategoryAmountChange = (category: string, amount: number) => {
+    if (!draftRecommendation) return;
+
+    const safeAmount = Number.isFinite(amount) ? Math.max(0, Math.round(amount)) : 0;
+    const nextRecommendation = applyCategoryBudgetEdits(draftRecommendation, {
+      [category]: safeAmount
+    });
+    setDraftRecommendation(nextRecommendation);
+  };
+
   const goNext = () => {
     setError(null);
 
@@ -375,6 +481,12 @@ export function SmartBudgetPage() {
     if (!draftRecommendation) {
       return;
     }
+
+    if (draftTotalDelta !== 0) {
+      setError(`分类预算合计需与月收入一致（当前差额 ${formatCurrency(draftTotalDelta)}）。`);
+      return;
+    }
+
     confirmPlan({ answers, recommendation: draftRecommendation });
     setSetupOpen(false);
     setMode('management');
@@ -477,6 +589,9 @@ export function SmartBudgetPage() {
                 </div>
                 <p className="smart-budget-health-score">
                   预算健康度 <strong>{managementOverview.healthScore}</strong> / 100
+                </p>
+                <p className="smart-budget-health-explain">
+                  {healthExplainText}（判定区间：&lt;80% 宽裕，80%~100% 健康，&gt;100% 超支）
                 </p>
               </div>
             </section>
@@ -583,6 +698,51 @@ export function SmartBudgetPage() {
                 </>
               ) : null}
             </section>
+
+            {categoryTrendRows.length ? (
+              <section className="smart-budget-trend-card" aria-label="预算执行趋势">
+                <h4>跨月趋势对比（各分类执行率）</h4>
+                <div className="smart-budget-trend-grid">
+                  {categoryTrendRows.map((row) => (
+                    <article key={row.category} className="smart-budget-trend-item">
+                      <header>
+                        <strong>{row.category}</strong>
+                        <span>
+                          {(row.points[row.points.length - 1]?.ratio * 100 || 0).toFixed(0)}%
+                        </span>
+                      </header>
+                      <div className="smart-budget-trend-bars">
+                        {row.points.map((point) => (
+                          <div
+                            key={`${row.category}-${point.monthKey}`}
+                            title={`${point.monthLabel}：${(point.ratio * 100).toFixed(1)}%`}
+                          >
+                            <span style={{ height: `${Math.min(point.ratio * 100, 160)}%` }} />
+                          </div>
+                        ))}
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {anomalyAlerts.length ? (
+              <section className="smart-budget-anomaly-card" aria-label="异常提醒">
+                <h4>异常提醒与调整建议</h4>
+                <ul>
+                  {anomalyAlerts.slice(0, 4).map((item) => (
+                    <li key={item.category}>
+                      <strong>{item.category}</strong> 预计月末支出{' '}
+                      {formatCurrency(item.projectedSpent)}， 约为预算的{' '}
+                      {(item.riskRatio * 100).toFixed(0)}%。建议优先减少非必要消费
+                      {formatCurrency(item.suggestedSaving)}，或将该分类预算上调到
+                      {formatCurrency(item.projectedSpent)}。
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
 
             {visibleRows.length ? (
               <div className="smart-budget-progress-list">
@@ -815,13 +975,33 @@ export function SmartBudgetPage() {
                     {draftRecommendation.categoryBudgets.map((row) => (
                       <tr key={row.category}>
                         <td>{row.category}</td>
-                        <td>{formatCurrency(row.amount)}</td>
+                        <td>
+                          <input
+                            aria-label={`${row.category}预算金额`}
+                            type="number"
+                            min={0}
+                            step={100}
+                            value={row.amount}
+                            onChange={(event) =>
+                              handleDraftCategoryAmountChange(
+                                row.category,
+                                Number(event.target.value)
+                              )
+                            }
+                          />
+                        </td>
                         <td>{(row.ratio * 100).toFixed(1)}%</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
+
+              <p
+                className={`smart-budget-delta ${draftTotalDelta === 0 ? 'balanced' : 'unbalanced'}`}
+              >
+                分类预算合计差额：{formatCurrency(draftTotalDelta)}（需为 0 才能确认）
+              </p>
 
               <div className="smart-budget-actions">
                 <button type="button" className="primary" onClick={handleConfirm}>


### PR DESCRIPTION
### Motivation
- Improve the smart budget flow so users can generate and tweak the recommended budget immediately after the 4-step questionnaire without jumping to the management page. 
- Make budget health more transparent by explaining the execution thresholds near the overview ring. 
- Help users track month-over-month execution trends and proactively surface categories at risk of overspending with actionable suggestions.

### Description
- Added `applyCategoryBudgetEdits` in `src/features/smart-budget/model/budgetPlanner.ts` to support inline edits of category amounts and recalc related fields (`monthlyFixedExpense`, `savingsAmount`, `flexibleBudget`, `disposableIncome`, and per-category `ratio`).
- Enhanced `SmartBudgetPage` (`src/pages/smart-budget/SmartBudgetPage.tsx`) to: add editable inputs on the recommendation result page, maintain a `draftTotalDelta` and require the category budgets to balance with `monthlyIncome` before confirmation, show a budget health explanation text next to the progress ring, compute cross-month category trend rows, and compute anomaly alerts with projected month-end spend and suggested adjustments.
- Added UI styles in `src/app/styles/global.css` for editable table inputs, delta status, trend cards and anomaly cards.
- Added a unit test for the new edit helper in `src/features/smart-budget/model/budgetPlanner.test.ts` and adjusted existing tests to ensure behavior remains correct.

### Testing
- Ran unit tests: `npm run test -- src/features/smart-budget/model/budgetPlanner.test.ts src/features/smart-budget/model/budgetInsights.test.ts` and all tests passed (2 files, 6 tests total passed). 
- Built the production bundle with `npm run build` which completed successfully. 
- Linted modified files with `npx eslint src/pages/smart-budget/SmartBudgetPage.tsx src/features/smart-budget/model/budgetPlanner.ts src/features/smart-budget/model/budgetPlanner.test.ts` and targeted files passed; the full repo `npm run lint` reports a pre-existing warning in `src/pages/dashboard/DashboardPage.tsx` unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ba3877c083288392f95c2ed78683)