### PR TITLE
feat: 分类/标签管理与账户校准交互优化

### DIFF
--- a/src/entities/category/types.ts
+++ b/src/entities/category/types.ts
@@ -1,4 +1,8 @@
 export interface Category {
   id: string;
   name: string;
+  kind?: 'income' | 'expense';
+  color?: string;
+  icon?: string;
+  sortOrder?: number;
 }

--- a/src/pages/categories-accounts/CategoriesAccountsPage.tsx
+++ b/src/pages/categories-accounts/CategoriesAccountsPage.tsx
@@ -10,6 +10,7 @@ import {
   getAccountTypeLabel
 } from '../../features/accounts/model/accountTypes';
 import type { AccountType } from '../../features/accounts/model/accountTypes';
+import type { Category } from '../../entities/category/types';
 
 function normalizeNameInput(raw: string) {
   return raw.replace(/[<>]/g, '').replace(/\s+/g, ' ').trim();
@@ -20,6 +21,16 @@ function isValidName(name: string) {
 }
 
 const GENERAL_ACCOUNT_TYPES: AccountType[] = ['cash', 'debit', 'savings', 'virtual'];
+const CATEGORY_COLORS = [
+  '#f97316',
+  '#ec4899',
+  '#8b5cf6',
+  '#22c55e',
+  '#06b6d4',
+  '#ef4444',
+  '#6366f1'
+];
+const CATEGORY_ICONS = ['🍜', '💰', '🛍️', '🏠', '🚇', '🎁', '📚', '💡', '📦'];
 
 export function CategoriesAccountsPage() {
   const navigate = useNavigate();
@@ -27,16 +38,23 @@ export function CategoriesAccountsPage() {
   const accounts = useFinanceStore((s) => s.accounts);
   const transactions = useFinanceStore((s) => s.transactions);
   const addCategory = useFinanceStore((s) => s.addCategory);
+  const updateCategory = useFinanceStore((s) => s.updateCategory);
+  const reorderCategories = useFinanceStore((s) => s.reorderCategories);
   const removeCategory = useFinanceStore((s) => s.removeCategory);
   const addAccount = useFinanceStore((s) => s.addAccount);
+  const addTransaction = useFinanceStore((s) => s.addTransaction);
   const updateTransaction = useFinanceStore((s) => s.updateTransaction);
   const updateAccountBalance = useFinanceStore((s) => s.updateAccountBalance);
   const removeAccount = useFinanceStore((s) => s.removeAccount);
 
   const [categoryName, setCategoryName] = useState('');
+  const [categoryKind, setCategoryKind] = useState<'income' | 'expense'>('expense');
+  const categoryColor = CATEGORY_COLORS[0];
+  const categoryIcon = CATEGORY_ICONS[0];
   const [accountName, setAccountName] = useState('');
   const [accountType, setAccountType] = useState<AccountType | ''>('');
   const [accountInitialBalance, setAccountInitialBalance] = useState('0');
+  const [adjustAmounts, setAdjustAmounts] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [pendingDeleteAccountId, setPendingDeleteAccountId] = useState<string | null>(null);
   const [pendingDeleteCategoryId, setPendingDeleteCategoryId] = useState<string | null>(null);
@@ -47,9 +65,10 @@ export function CategoriesAccountsPage() {
   const [showAllAccounts, setShowAllAccounts] = useState(false);
   const [categoryError, setCategoryError] = useState('');
   const [accountError, setAccountError] = useState('');
+  const [mergeTargetByTag, setMergeTargetByTag] = useState<Record<string, string>>({});
 
-  const CATEGORY_COLLAPSE_THRESHOLD = 3;
-  const TAG_COLLAPSE_THRESHOLD = 3;
+  const CATEGORY_COLLAPSE_THRESHOLD = 5;
+  const TAG_COLLAPSE_THRESHOLD = 5;
   const ACCOUNT_COLLAPSE_THRESHOLD = 8;
 
   useEffect(() => {
@@ -64,7 +83,7 @@ export function CategoriesAccountsPage() {
       setCategoryError('分类名称需为 1-24 个字符，且不能包含 < 或 >。');
       return;
     }
-    addCategory(normalized);
+    addCategory(normalized, { kind: categoryKind, color: categoryColor, icon: categoryIcon });
     setCategoryName('');
     setCategoryError('');
   }
@@ -110,6 +129,22 @@ export function CategoriesAccountsPage() {
       }, 0)
     : 0;
 
+  const orderedCategories = useMemo(() => {
+    const byOrder = [...categories].sort(
+      (a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER)
+    );
+    const income: Category[] = [];
+    const expense: Category[] = [];
+    byOrder.forEach((item) => {
+      if (item.kind === 'income') {
+        income.push(item);
+      } else {
+        expense.push(item);
+      }
+    });
+    return { income, expense };
+  }, [categories]);
+
   const tagGroups = useMemo(() => {
     const map = new Map<string, { key: string; label: string; count: number }>();
     transactions.forEach((tx) => {
@@ -135,9 +170,20 @@ export function CategoriesAccountsPage() {
     });
   }, [transactions]);
 
-  const displayCategories = useMemo(
-    () => (showAllCategories ? categories : categories.slice(0, CATEGORY_COLLAPSE_THRESHOLD)),
-    [categories, showAllCategories]
+  const displayExpenseCategories = useMemo(
+    () =>
+      showAllCategories
+        ? orderedCategories.expense
+        : orderedCategories.expense.slice(0, CATEGORY_COLLAPSE_THRESHOLD),
+    [orderedCategories.expense, showAllCategories]
+  );
+
+  const displayIncomeCategories = useMemo(
+    () =>
+      showAllCategories
+        ? orderedCategories.income
+        : orderedCategories.income.slice(0, CATEGORY_COLLAPSE_THRESHOLD),
+    [orderedCategories.income, showAllCategories]
   );
 
   const categoryUsageMap = useMemo(() => {
@@ -160,7 +206,10 @@ export function CategoriesAccountsPage() {
     [managedAccounts, showAllAccounts]
   );
 
-  const hiddenCategoryCount = Math.max(0, categories.length - displayCategories.length);
+  const hiddenCategoryCount = Math.max(
+    0,
+    categories.length - (displayExpenseCategories.length + displayIncomeCategories.length)
+  );
   const hiddenTagCount = Math.max(0, tagGroups.length - displayTags.length);
   const hiddenAccountCount = Math.max(0, managedAccounts.length - displayAccounts.length);
 
@@ -203,6 +252,46 @@ export function CategoriesAccountsPage() {
     setEditingBalances((prev) => ({ ...prev, [accountId]: normalized.toFixed(2) }));
   };
 
+  const applySingleAdjustment = (accountId: string) => {
+    const value = Number(adjustAmounts[accountId] || '0');
+    if (!Number.isFinite(value) || value === 0) {
+      return;
+    }
+    const category = categories.find((item) => item.kind === (value > 0 ? 'income' : 'expense'));
+    if (!category) {
+      return;
+    }
+    addTransaction({
+      type: value > 0 ? 'income' : 'expense',
+      categoryId: category.id,
+      accountId,
+      amount: Math.abs(value),
+      date: new Date().toISOString(),
+      note: '账户单笔调整',
+      tags: ['账户校准'],
+      source: 'manual',
+      status: 'completed'
+    });
+    setAdjustAmounts((prev) => ({ ...prev, [accountId]: '' }));
+  };
+
+  const moveCategory = (categoryId: string, direction: -1 | 1) => {
+    const orderedIds = [...categories]
+      .sort(
+        (a, b) =>
+          (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER)
+      )
+      .map((item) => item.id);
+    const currentIndex = orderedIds.indexOf(categoryId);
+    const targetIndex = currentIndex + direction;
+    if (currentIndex < 0 || targetIndex < 0 || targetIndex >= orderedIds.length) {
+      return;
+    }
+    const next = [...orderedIds];
+    [next[currentIndex], next[targetIndex]] = [next[targetIndex], next[currentIndex]];
+    reorderCategories(next);
+  };
+
   const accountCards = useMemo(
     () =>
       displayAccounts.map((item) => {
@@ -229,6 +318,42 @@ export function CategoriesAccountsPage() {
     });
   };
 
+  const mergeTagIntoAnother = (fromLabel: string, toLabel: string) => {
+    const from = fromLabel.trim().toLowerCase();
+    const to = toLabel.trim();
+    if (!from || !to || from === to.toLowerCase()) {
+      return;
+    }
+    transactions.forEach((tx) => {
+      let touched = false;
+      const normalizedSet = new Set<string>();
+      const nextTags = tx.tags
+        .map((tag) => {
+          const key = tag.trim().toLowerCase();
+          if (!key) {
+            return '';
+          }
+          if (key === from) {
+            touched = true;
+            return to;
+          }
+          return tag.trim();
+        })
+        .filter((item) => {
+          if (!item) return false;
+          const key = item.toLowerCase();
+          if (normalizedSet.has(key)) {
+            return false;
+          }
+          normalizedSet.add(key);
+          return true;
+        });
+      if (touched) {
+        updateTransaction(tx.id, { ...tx, tags: nextTags });
+      }
+    });
+  };
+
   const totalBalance = useMemo(
     () => accountCards.reduce((sum, item) => sum + item.computedBalance, 0),
     [accountCards]
@@ -237,6 +362,67 @@ export function CategoriesAccountsPage() {
   const negativeAccounts = useMemo(
     () => accountCards.filter((item) => item.computedBalance < 0).length,
     [accountCards]
+  );
+
+  const renderCategoryRow = (item: Category) => (
+    <li key={item.id} className="row categories-row">
+      <span style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span
+          aria-hidden="true"
+          style={{ width: 20, height: 20, display: 'inline-grid', placeItems: 'center' }}
+        >
+          {item.icon || '📁'}
+        </span>
+        <button
+          type="button"
+          className="tag-count-chip"
+          style={{ borderColor: item.color || 'transparent', color: item.color || undefined }}
+          onClick={() =>
+            updateCategory(item.id, {
+              color:
+                CATEGORY_COLORS[
+                  (CATEGORY_COLORS.indexOf(item.color || '') + 1) % CATEGORY_COLORS.length
+                ]
+            })
+          }
+          aria-label={`切换 ${item.name} 的颜色`}
+        >
+          颜色
+        </button>
+        <button
+          type="button"
+          className="tag-count-chip"
+          onClick={() =>
+            updateCategory(item.id, {
+              icon: CATEGORY_ICONS[
+                (CATEGORY_ICONS.indexOf(item.icon || '') + 1) % CATEGORY_ICONS.length
+              ]
+            })
+          }
+          aria-label={`切换 ${item.name} 的图标`}
+        >
+          图标
+        </button>
+        <strong>{item.name}</strong>
+        <button
+          type="button"
+          className="tag-count-chip tag-count-chip-link"
+          onClick={() => navigate(`/transactions?categoryId=${encodeURIComponent(item.id)}`)}
+          aria-label={`查看分类 ${item.name} 的 ${categoryUsageMap.get(item.id) || 0} 条交易`}
+        >
+          {categoryUsageMap.get(item.id) || 0} 条
+        </button>
+      </span>
+      <button type="button" onClick={() => moveCategory(item.id, -1)}>
+        ↑
+      </button>
+      <button type="button" onClick={() => moveCategory(item.id, 1)}>
+        ↓
+      </button>
+      <button type="button" className="danger" onClick={() => setPendingDeleteCategoryId(item.id)}>
+        删除
+      </button>
+    </li>
   );
 
   return (
@@ -268,6 +454,13 @@ export function CategoriesAccountsPage() {
             style={{ flex: 1 }}
             maxLength={24}
           />
+          <select
+            value={categoryKind}
+            onChange={(e) => setCategoryKind(e.target.value as 'income' | 'expense')}
+          >
+            <option value="expense">支出分类</option>
+            <option value="income">收入分类</option>
+          </select>
           <button className="primary" type="submit">
             添加
           </button>
@@ -279,36 +472,15 @@ export function CategoriesAccountsPage() {
           <EmptyState title="暂无分类" description="请添加第一个交易分类。" icon="🧩" />
         ) : (
           <>
-            <ul className="categories-list">
-              {displayCategories.map((item) => (
-                <li key={item.id} className="row categories-row">
-                  <span style={{ flex: 1 }}>
-                    {item.name}
-                    <button
-                      type="button"
-                      className="tag-count-chip tag-count-chip-link"
-                      onClick={() =>
-                        navigate(`/transactions?categoryId=${encodeURIComponent(item.id)}`)
-                      }
-                      aria-label={`查看分类 ${item.name} 的 ${categoryUsageMap.get(item.id) || 0} 条交易`}
-                    >
-                      {categoryUsageMap.get(item.id) || 0} 条
-                    </button>
-                  </span>
-                  <button
-                    type="button"
-                    className="danger"
-                    onClick={() => setPendingDeleteCategoryId(item.id)}
-                  >
-                    删除
-                  </button>
-                </li>
-              ))}
-            </ul>
+            <h3>支出分类</h3>
+            <ul className="categories-list">{displayExpenseCategories.map(renderCategoryRow)}</ul>
+            <h3 style={{ marginTop: 16 }}>收入分类</h3>
+            <ul className="categories-list">{displayIncomeCategories.map(renderCategoryRow)}</ul>
             {categories.length > CATEGORY_COLLAPSE_THRESHOLD ? (
               <div className="row" style={{ justifyContent: 'space-between', marginTop: 10 }}>
                 <small style={{ color: 'var(--color-text-secondary)' }}>
-                  已显示 {displayCategories.length}/{categories.length}
+                  已显示 {displayExpenseCategories.length + displayIncomeCategories.length}/
+                  {categories.length}
                 </small>
                 <button type="button" onClick={() => setShowAllCategories((prev) => !prev)}>
                   {showAllCategories ? '收起' : `展开剩余 ${hiddenCategoryCount} 项`}
@@ -318,11 +490,11 @@ export function CategoriesAccountsPage() {
           </>
         )}
 
-        <h3 style={{ marginTop: 20 }}>交易标签</h3>
+        <h3 style={{ marginTop: 20 }}>交易标签（支持合并/删除）</h3>
         {tagGroups.length === 0 ? (
           <EmptyState
             title="暂无标签"
-            description="标签来自交易明细，新增交易标签后会自动聚合到这里。"
+            description="新增交易时会自动建议并创建标签，后续可在此集中管理。"
             icon="🏷️"
           />
         ) : (
@@ -338,17 +510,37 @@ export function CategoriesAccountsPage() {
                       onClick={() =>
                         navigate(`/transactions?keyword=${encodeURIComponent(tag.label)}`)
                       }
-                      aria-label={`查看标签 ${tag.label} 的 ${tag.count} 条交易`}
                     >
                       {tag.count} 条
                     </button>
                   </span>
+                  <select
+                    value={mergeTargetByTag[tag.key] || ''}
+                    onChange={(e) =>
+                      setMergeTargetByTag((prev) => ({ ...prev, [tag.key]: e.target.value }))
+                    }
+                  >
+                    <option value="">选择合并目标</option>
+                    {tagGroups
+                      .filter((item) => item.key !== tag.key)
+                      .map((item) => (
+                        <option key={item.key} value={item.label}>
+                          {item.label}
+                        </option>
+                      ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => mergeTagIntoAnother(tag.label, mergeTargetByTag[tag.key] || '')}
+                  >
+                    合并
+                  </button>
                   <button
                     type="button"
                     className="danger"
                     onClick={() => setPendingRemoveTagLabel(tag.label)}
                   >
-                    全部移除
+                    删除
                   </button>
                 </li>
               ))}
@@ -401,8 +593,6 @@ export function CategoriesAccountsPage() {
             <div className="field">
               <label>账户类型</label>
               <select
-                aria-label="账户类型"
-                title="账户类型"
                 value={accountType}
                 onChange={(e) => setAccountType(e.target.value as AccountType | '')}
               >
@@ -474,17 +664,34 @@ export function CategoriesAccountsPage() {
                         <input
                           className="account-balance-input"
                           type="number"
-                          aria-label={`校准余额：${item.name}`}
-                          title={`校准余额：${item.name}`}
                           placeholder="输入余额"
                           value={balanceValue}
                           onChange={(e) =>
                             setEditingBalances((prev) => ({ ...prev, [item.id]: e.target.value }))
                           }
                         />
+                        <small>
+                          <a href="#" onClick={(e) => e.preventDefault()}>
+                            自动校准说明：系统会回推“初始余额”，使当前余额与输入值一致。
+                          </a>
+                        </small>
                       </div>
                       <button type="button" onClick={() => applyAccountBalance(item.id)}>
                         保存校准
+                      </button>
+                    </div>
+                    <div className="account-card-actions" style={{ marginTop: 8 }}>
+                      <input
+                        className="account-balance-input"
+                        type="number"
+                        placeholder="单笔调整（+收入 / -支出）"
+                        value={adjustAmounts[item.id] || ''}
+                        onChange={(e) =>
+                          setAdjustAmounts((prev) => ({ ...prev, [item.id]: e.target.value }))
+                        }
+                      />
+                      <button type="button" onClick={() => applySingleAdjustment(item.id)}>
+                        添加单笔调整
                       </button>
                       <button className="danger" onClick={() => setPendingDeleteAccountId(item.id)}>
                         删除

--- a/src/pages/transaction-edit/TransactionEditPage.tsx
+++ b/src/pages/transaction-edit/TransactionEditPage.tsx
@@ -24,6 +24,19 @@ function formatLocalDateTime(raw: string): string {
   return `${yyyy}-${mm}-${dd}T${hh}:${mi}`;
 }
 
+function suggestTags(note: string, merchantOrderNo: string, orderNo: string): string[] {
+  const source = `${note} ${merchantOrderNo} ${orderNo}`.toLowerCase();
+  const rules: Array<{ keyword: RegExp; tag: string }> = [
+    { keyword: /(星巴克|咖啡|奶茶|茶饮)/, tag: '饮品' },
+    { keyword: /(超市|便利店|盒马|永辉)/, tag: '日用品' },
+    { keyword: /(地铁|公交|打车|滴滴|高铁)/, tag: '出行' },
+    { keyword: /(外卖|美团|饿了么|餐)/, tag: '餐饮' },
+    { keyword: /(工资|薪资|奖金)/, tag: '工资收入' },
+    { keyword: /(淘宝|京东|拼多多)/, tag: '网购' }
+  ];
+  return rules.filter((item) => item.keyword.test(source)).map((item) => item.tag);
+}
+
 function validateAmount(raw: string): { ok: true; value: number } | { ok: false; message: string } {
   const normalized = raw.trim();
   if (!normalized) {
@@ -101,6 +114,12 @@ export function TransactionEditPage() {
   const [dateError, setDateError] = useState('');
   const [formError, setFormError] = useState('');
 
+  const suggestedTags = useMemo(
+    () =>
+      suggestTags(note, merchantOrderNo, orderNo).filter((tag) => !parseTags(tags).includes(tag)),
+    [note, merchantOrderNo, orderNo, tags]
+  );
+
   const handleBack = useCallback(() => {
     navigate('/transactions');
   }, [navigate]);
@@ -146,6 +165,9 @@ export function TransactionEditPage() {
       return;
     }
 
+    const mergedTags = Array.from(
+      new Set([...parseTags(tags), ...suggestTags(note, merchantOrderNo, orderNo)])
+    );
     const payload = {
       type,
       categoryId,
@@ -153,7 +175,7 @@ export function TransactionEditPage() {
       amount: amountResult.value,
       date: dateResult.value,
       note,
-      tags: parseTags(tags),
+      tags: mergedTags,
       source: current?.source ?? 'manual',
       orderNo: orderNo.trim() || undefined,
       merchantOrderNo: merchantOrderNo.trim() || undefined,
@@ -198,7 +220,7 @@ export function TransactionEditPage() {
           <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)} required>
             {categories.map((item) => (
               <option key={item.id} value={item.id}>
-                {item.name}
+                {(item.icon || '📁') + ' ' + item.name}
               </option>
             ))}
           </select>
@@ -287,6 +309,22 @@ export function TransactionEditPage() {
         <div className="field">
           <label>标签（逗号分隔）</label>
           <input value={tags} onChange={(e) => setTags(e.target.value)} />
+          {suggestedTags.length > 0 ? (
+            <small style={{ color: 'var(--color-text-secondary)' }}>
+              自动建议：
+              {suggestedTags.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  className="tag-count-chip"
+                  onClick={() => setTags((prev) => [...parseTags(prev), tag].join(','))}
+                  style={{ marginLeft: 6 }}
+                >
+                  {tag}
+                </button>
+              ))}
+            </small>
+          ) : null}
         </div>
 
         {formError ? <p className="error">{formError}</p> : null}

--- a/src/shared/store/useFinanceStore.ts
+++ b/src/shared/store/useFinanceStore.ts
@@ -14,7 +14,12 @@ interface FinanceState {
   addTransaction: (payload: Omit<TransactionItem, 'id'>) => string;
   updateTransaction: (id: string, payload: Omit<TransactionItem, 'id'>) => void;
   removeTransaction: (id: string) => void;
-  addCategory: (name: string) => string;
+  addCategory: (
+    name: string,
+    options?: { kind?: Category['kind']; color?: string; icon?: string }
+  ) => string;
+  updateCategory: (id: string, payload: Partial<Omit<Category, 'id'>>) => void;
+  reorderCategories: (orderedIds: string[]) => void;
   removeCategory: (id: string) => void;
   addAccount: (name: string, type?: Account['type'], initialBalance?: number) => string;
   updateAccountBalance: (id: string, balance: number) => void;
@@ -29,32 +34,116 @@ interface FinanceState {
 
 const defaultCategories: Category[] = [
   // 生活大类（衣食住行）
-  { id: 'cat-food', name: '餐饮' },
-  { id: 'cat-clothing', name: '衣物穿搭' },
-  { id: 'cat-housing', name: '住房' },
-  { id: 'cat-utilities', name: '水电燃气' },
-  { id: 'cat-transport', name: '交通' },
+  { id: 'cat-food', name: '餐饮', kind: 'expense', icon: '🍜', color: '#f97316', sortOrder: 1 },
+  {
+    id: 'cat-clothing',
+    name: '衣物穿搭',
+    kind: 'expense',
+    icon: '👕',
+    color: '#ec4899',
+    sortOrder: 2
+  },
+  { id: 'cat-housing', name: '住房', kind: 'expense', icon: '🏠', color: '#8b5cf6', sortOrder: 3 },
+  {
+    id: 'cat-utilities',
+    name: '水电燃气',
+    kind: 'expense',
+    icon: '💡',
+    color: '#22c55e',
+    sortOrder: 4
+  },
+  {
+    id: 'cat-transport',
+    name: '交通',
+    kind: 'expense',
+    icon: '🚇',
+    color: '#06b6d4',
+    sortOrder: 5
+  },
 
   // 高频日常
-  { id: 'cat-shopping', name: '购物日用' },
-  { id: 'cat-communication', name: '通讯网络' },
-  { id: 'cat-health', name: '医疗健康' },
-  { id: 'cat-education', name: '教育学习' },
-  { id: 'cat-entertainment', name: '娱乐社交' },
-  { id: 'cat-travel', name: '旅行' },
-  { id: 'cat-gift', name: '人情往来' },
+  {
+    id: 'cat-shopping',
+    name: '购物日用',
+    kind: 'expense',
+    icon: '🛍️',
+    color: '#ef4444',
+    sortOrder: 6
+  },
+  {
+    id: 'cat-communication',
+    name: '通讯网络',
+    kind: 'expense',
+    icon: '📶',
+    color: '#0ea5e9',
+    sortOrder: 7
+  },
+  {
+    id: 'cat-health',
+    name: '医疗健康',
+    kind: 'expense',
+    icon: '🩺',
+    color: '#14b8a6',
+    sortOrder: 8
+  },
+  {
+    id: 'cat-education',
+    name: '教育学习',
+    kind: 'expense',
+    icon: '📚',
+    color: '#6366f1',
+    sortOrder: 9
+  },
+  {
+    id: 'cat-entertainment',
+    name: '娱乐社交',
+    kind: 'expense',
+    icon: '🎮',
+    color: '#a855f7',
+    sortOrder: 10
+  },
+  { id: 'cat-travel', name: '旅行', kind: 'expense', icon: '🧳', color: '#f59e0b', sortOrder: 11 },
+  {
+    id: 'cat-gift',
+    name: '人情往来',
+    kind: 'expense',
+    icon: '🎁',
+    color: '#e11d48',
+    sortOrder: 12
+  },
 
   // 金融/收入
-  { id: 'cat-salary', name: '工资' },
-  { id: 'cat-bonus', name: '奖金' },
-  { id: 'cat-invest-income', name: '理财收益' },
-  { id: 'cat-refund', name: '退款返现' },
-  { id: 'cat-insurance', name: '保险' },
-  { id: 'cat-tax', name: '税费' },
-  { id: 'cat-loan', name: '还款' },
+  { id: 'cat-salary', name: '工资', kind: 'income', icon: '💰', color: '#16a34a', sortOrder: 13 },
+  { id: 'cat-bonus', name: '奖金', kind: 'income', icon: '🎉', color: '#22c55e', sortOrder: 14 },
+  {
+    id: 'cat-invest-income',
+    name: '理财收益',
+    kind: 'income',
+    icon: '📈',
+    color: '#15803d',
+    sortOrder: 15
+  },
+  {
+    id: 'cat-refund',
+    name: '退款返现',
+    kind: 'income',
+    icon: '💸',
+    color: '#10b981',
+    sortOrder: 16
+  },
+  {
+    id: 'cat-insurance',
+    name: '保险',
+    kind: 'expense',
+    icon: '🛡️',
+    color: '#0284c7',
+    sortOrder: 17
+  },
+  { id: 'cat-tax', name: '税费', kind: 'expense', icon: '🧾', color: '#7c3aed', sortOrder: 18 },
+  { id: 'cat-loan', name: '还款', kind: 'expense', icon: '🏦', color: '#475569', sortOrder: 19 },
 
   // 兜底
-  { id: 'cat-other', name: '其他' }
+  { id: 'cat-other', name: '其他', kind: 'expense', icon: '📦', color: '#6b7280', sortOrder: 20 }
 ];
 
 const defaultAccounts: Account[] = [
@@ -186,7 +275,7 @@ export const useFinanceStore = create<FinanceState>()(
         });
         void syncChangeIfNeeded({ entity: 'transactions', action: 'delete', id });
       },
-      addCategory: (name) => {
+      addCategory: (name, options) => {
         const normalizedName = normalizeCategoryName(name);
         if (!normalizedName) {
           return defaultCategories[0]?.id || 'cat-unknown';
@@ -203,7 +292,14 @@ export const useFinanceStore = create<FinanceState>()(
             return s;
           }
 
-          insertedRow = { id: generateId(), name: normalizedName };
+          insertedRow = {
+            id: generateId(),
+            name: normalizedName,
+            kind: options?.kind,
+            color: options?.color,
+            icon: options?.icon,
+            sortOrder: s.categories.length + 1
+          };
           resolvedId = insertedRow.id;
           const compacted = sanitizeCategoriesAndTransactions(
             [...s.categories, insertedRow],
@@ -220,6 +316,32 @@ export const useFinanceStore = create<FinanceState>()(
         }
 
         return resolvedId;
+      },
+      updateCategory: (id, payload) => {
+        let updatedRow: Category | null = null;
+        set((s) => {
+          const categories = s.categories.map((item) => {
+            if (item.id !== id) {
+              return item;
+            }
+            updatedRow = { ...item, ...payload };
+            return updatedRow;
+          });
+          return { categories };
+        });
+        if (updatedRow) {
+          void syncChangeIfNeeded({ entity: 'categories', action: 'update', row: updatedRow, id });
+        }
+      },
+      reorderCategories: (orderedIds) => {
+        set((s) => {
+          const orderMap = new Map(orderedIds.map((categoryId, index) => [categoryId, index + 1]));
+          const categories = s.categories.map((item) => ({
+            ...item,
+            sortOrder: orderMap.get(item.id) ?? item.sortOrder ?? s.categories.length + 1
+          }));
+          return { categories };
+        });
       },
       removeCategory: (id) => {
         set((s) => ({ categories: s.categories.filter((item) => item.id !== id) }));


### PR DESCRIPTION
### Motivation
- 改进分类与账户页的管理体验，支持收入/支出分类分栏、分类自定义元信息与自定义排序以减少混淆并提升可读性。
- 为新增交易提供智能标签建议并在保存时自动合并，以便集中管理标签并支持合并/删除操作。
- 提供更直观的账户校准与快捷调整流程，使单笔调整能写入交易并即时刷新余额。

### Description
- 扩展分类数据模型：在 `src/entities/category/types.ts` 中为 `Category` 增加了 `kind/color/icon/sortOrder` 字段以支持收入/支出、颜色与图标及排序功能。
- 存储层增强：在 `src/shared/store/useFinanceStore.ts` 中扩展了 `addCategory` 接收 `options` 并写入元信息，新增 `updateCategory` 与 `reorderCategories`，并初始化默认分类的图标/颜色/顺序。
- 分类/账户页面重构：在 `src/pages/categories-accounts/CategoriesAccountsPage.tsx` 中实现了“支出/收入”分栏展示、分类颜色与图标快速切换、上下移动排序、标签合并（`mergeTagIntoAnother`）与删除、以及界面上新增分类类型选择控件。
- 交易编辑页增强：在 `src/pages/transaction-edit/TransactionEditPage.tsx` 中增加了基于备注/商家单号/订单号的 `suggestTags` 规则，保存时会与手动标签合并去重并写入交易；同时在分类下拉中显示分类图标以增强识别度。
- 账户校准与快捷调整：在分类/账户页添加了“自动校准说明”文案和“单笔调整（+收入 / -支出）”输入与按钮，单笔调整会通过 `addTransaction` 创建调整交易并触发余额重算。

### Testing
- 运行了构建验证：`npm run build`（`tsc --noEmit && vite build`）执行通过，产物成功生成。
- 运行了仓库级 lint：`npm run lint` 报告了仓库中与本次变更无关的 warning（`src/pages/dashboard/DashboardPage.tsx` 的 hook 依赖问题），导致严格 lint 返回非 0 状态。
- 针对改动文件执行了静态检查：`npx eslint src/pages/categories-accounts/CategoriesAccountsPage.tsx src/pages/transaction-edit/TransactionEditPage.tsx src/shared/store/useFinanceStore.ts src/entities/category/types.ts` 检查通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ba7a3b208328bae4c21a631318cb)