### PR TITLE
feat: 优化交易流水页分组展示、筛选与 AI 商户识别

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -7064,3 +7064,67 @@ body.exchange-resizing {
   border-radius: 10px;
   padding: 10px;
 }
+
+.transaction-insight-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.transaction-monthly-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.transaction-monthly-summary > div {
+  border: 1px solid var(--color-border, #e6e8ec);
+  border-radius: 10px;
+  padding: 10px;
+  background: var(--color-bg-soft, #f8fafc);
+}
+
+.transaction-monthly-summary span {
+  display: block;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.transaction-advanced-filters {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.transaction-search-history,
+.transaction-tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.transaction-group-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.transaction-group-card {
+  border: 1px solid var(--color-border, #e6e8ec);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.transaction-group-card ul {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.transaction-group-card li {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 13px;
+  margin-bottom: 6px;
+}

--- a/src/features/transactions/components/TransactionTable.test.tsx
+++ b/src/features/transactions/components/TransactionTable.test.tsx
@@ -31,6 +31,7 @@ describe('TransactionTable', () => {
           amountMax: '',
           tags: '',
           merchant: '',
+          location: '',
           orderNo: '',
           merchantOrderNo: '',
           note: ''
@@ -134,6 +135,7 @@ describe('TransactionTable', () => {
           amountMax: '',
           tags: '',
           merchant: '',
+          location: '',
           orderNo: '',
           merchantOrderNo: '',
           note: ''
@@ -248,6 +250,7 @@ describe('TransactionTable', () => {
           amountMax: '',
           tags: '',
           merchant: '',
+          location: '',
           orderNo: '',
           merchantOrderNo: '',
           note: ''

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -40,6 +40,7 @@ export interface TransactionQuickFilters {
   amountMax: string;
   tags: string;
   merchant: string;
+  location: string;
   orderNo: string;
   merchantOrderNo: string;
   note: string;
@@ -600,9 +601,6 @@ export function TransactionTable({
                             value={quickFilters.amountMin}
                             onChange={(event) => {
                               onQuickFilterChange('amountMin', event.target.value);
-                              if (quickFilters.amountMax) {
-                                onQuickFilterChange('amountMax', '');
-                              }
                             }}
                             placeholder="最小金额"
                           />

--- a/src/pages/transaction-edit/TransactionEditPage.tsx
+++ b/src/pages/transaction-edit/TransactionEditPage.tsx
@@ -1,7 +1,16 @@
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { TransactionStatus } from '../../entities/transaction/types';
+import { sendAiChat } from '../../features/assistant/api/openaiCompatibleClient';
+import { extractJsonString } from '../../features/assistant/workbench/workbenchUtils';
 import { useFinanceStore } from '../../shared/store/useFinanceStore';
+import { useAiSettings } from '../../shared/store/useAiSettings';
+
+interface RecognitionSuggestion {
+  merchant: string;
+  category: string;
+  reason: string;
+}
 
 const MAX_AMOUNT = 999999999.99;
 const MIN_DATE = '2000-01-01T00:00';
@@ -80,6 +89,9 @@ export function TransactionEditPage() {
   const transactions = useFinanceStore((s) => s.transactions);
   const addTransaction = useFinanceStore((s) => s.addTransaction);
   const updateTransaction = useFinanceStore((s) => s.updateTransaction);
+  const aiBaseUrl = useAiSettings((s) => s.baseUrl);
+  const aiApiKey = useAiSettings((s) => s.apiKey);
+  const aiModel = useAiSettings((s) => s.model);
 
   const current = useMemo(() => transactions.find((item) => item.id === id), [transactions, id]);
   const [type, setType] = useState<'income' | 'expense' | 'budget' | 'repayment'>(
@@ -100,10 +112,36 @@ export function TransactionEditPage() {
   const [amountError, setAmountError] = useState('');
   const [dateError, setDateError] = useState('');
   const [formError, setFormError] = useState('');
+  const [recognizing, setRecognizing] = useState(false);
+  const [suggestion, setSuggestion] = useState<RecognitionSuggestion | null>(null);
 
   const handleBack = useCallback(() => {
     navigate('/transactions');
   }, [navigate]);
+
+  const recognizeMerchant = useCallback(async () => {
+    const text = note.trim();
+    if (!text || !aiBaseUrl || !aiModel) return;
+    setRecognizing(true);
+    try {
+      const prompt = `请识别交易备注中的商户名称与分类，只返回 JSON：{"merchant":"", "category":"", "reason":""}。备注：${text}`;
+      const res = await sendAiChat({
+        baseUrl: aiBaseUrl,
+        apiKey: aiApiKey,
+        model: aiModel,
+        messages: [{ role: 'user', text: prompt }]
+      });
+      const raw = extractJsonString(res?.content || '');
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as RecognitionSuggestion;
+      if (!parsed?.merchant && !parsed?.category) return;
+      setSuggestion(parsed);
+    } catch {
+      // ignore suggestion failures
+    } finally {
+      setRecognizing(false);
+    }
+  }, [aiApiKey, aiBaseUrl, aiModel, note]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -282,6 +320,37 @@ export function TransactionEditPage() {
         <div className="field">
           <label>备注</label>
           <textarea value={note} onChange={(e) => setNote(e.target.value)} />
+          <div className="row" style={{ marginTop: 8 }}>
+            <button type="button" onClick={() => void recognizeMerchant()} disabled={recognizing}>
+              {recognizing ? 'AI 识别中...' : 'AI 识别商户与分类'}
+            </button>
+          </div>
+          {suggestion ? (
+            <small>
+              建议：商户「{suggestion.merchant || '未识别'}」，分类「
+              {suggestion.category || '未识别'}」。
+              <button
+                type="button"
+                onClick={() => {
+                  if (suggestion.merchant) {
+                    setNote((prev) =>
+                      prev.includes(suggestion.merchant)
+                        ? prev
+                        : `${suggestion.merchant} ${prev}`.trim()
+                    );
+                  }
+                  if (suggestion.category) {
+                    const matched = categories.find((item) =>
+                      item.name.includes(suggestion.category)
+                    );
+                    if (matched) setCategoryId(matched.id);
+                  }
+                }}
+              >
+                应用建议
+              </button>
+            </small>
+          ) : null}
         </div>
 
         <div className="field">

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -9,7 +9,7 @@ import {
   BillImportMode,
   parseBillFileToTransactions
 } from '../../shared/lib/billImport';
-import { formatDate } from '../../shared/lib/format';
+import { formatCurrency, formatDate } from '../../shared/lib/format';
 import { resolveImportDefaultAccountId } from '../../shared/lib/importAccount';
 import { Toast, ToastVariant } from '../../shared/ui/Toast';
 import { ConfirmDialog } from '../../shared/ui/ConfirmDialog';
@@ -50,10 +50,30 @@ const DEFAULT_QUICK_FILTERS: TransactionQuickFilters = {
   amountMax: '',
   tags: '',
   merchant: '',
+  location: '',
   orderNo: '',
   merchantOrderNo: '',
   note: ''
 };
+
+const TX_SEARCH_HISTORY_KEY = 'ledgerflow.transactions.searchHistory';
+
+function getWeekRange(offsetWeeks = 0): { from: Date; to: Date } {
+  const now = new Date();
+  const day = now.getDay() || 7;
+  const monday = new Date(now);
+  monday.setHours(0, 0, 0, 0);
+  monday.setDate(now.getDate() - day + 1 + offsetWeeks * 7);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  sunday.setHours(23, 59, 59, 999);
+  return { from: monday, to: sunday };
+}
+
+function extractLocation(note: string): string {
+  const match = note.match(/(?:@|在|于|地点[:：])\s*([\u4e00-\u9fa5A-Za-z0-9·\-\s]{2,20})/);
+  return match?.[1]?.trim() || '';
+}
 
 const DEFAULT_VISIBLE_COLUMNS: Record<TransactionColumnKey, boolean> = {
   date: true,
@@ -356,6 +376,15 @@ export function TransactionsPage() {
   });
 
   const [quickFilters, setQuickFilters] = useState<TransactionQuickFilters>(DEFAULT_QUICK_FILTERS);
+  const [searchHistory, setSearchHistory] = useState<string[]>(() => {
+    try {
+      const raw = window.localStorage.getItem(TX_SEARCH_HISTORY_KEY);
+      const parsed = raw ? (JSON.parse(raw) as string[]) : [];
+      return Array.isArray(parsed) ? parsed.filter(Boolean).slice(0, 8) : [];
+    } catch {
+      return [];
+    }
+  });
   const [sortKey, setSortKey] = useState<TransactionSortKey>('date');
   const [sortDirection, setSortDirection] = useState<TransactionSortDirection>('desc');
   const [visibleColumns, setVisibleColumns] = useState<Record<TransactionColumnKey, boolean>>(() =>
@@ -441,6 +470,10 @@ export function TransactionsPage() {
   }, [columnWidths]);
 
   useEffect(() => {
+    window.localStorage.setItem(TX_SEARCH_HISTORY_KEY, JSON.stringify(searchHistory));
+  }, [searchHistory]);
+
+  useEffect(() => {
     const categoryId = searchParams.get('categoryId') ?? '';
     if (!categoryId) {
       return;
@@ -523,8 +556,12 @@ export function TransactionsPage() {
      * 导致列表隐式追加“金额必须等于 0”，于是出现“交易记录为空”。
      */
     const hasAmountMin = amountMinRaw.length > 0 && Number.isFinite(amountMin);
+    const amountMaxRaw = quickFilters.amountMax.trim();
+    const amountMax = Number(amountMaxRaw);
+    const hasAmountMax = amountMaxRaw.length > 0 && Number.isFinite(amountMax);
     const tagsFilter = quickFilters.tags.trim().toLowerCase();
     const merchantFilter = quickFilters.merchant.trim().toLowerCase();
+    const locationFilter = quickFilters.location.trim().toLowerCase();
     const orderNoFilter = quickFilters.orderNo.trim().toLowerCase();
     const merchantOrderNoFilter = quickFilters.merchantOrderNo.trim().toLowerCase();
     const noteFilter = quickFilters.note.trim().toLowerCase();
@@ -546,8 +583,15 @@ export function TransactionsPage() {
         !merchantFilter ||
         (row.item.note || '').toLowerCase().includes(merchantFilter) ||
         (row.item.merchantOrderNo || '').toLowerCase().includes(merchantFilter);
+      const locationText = extractLocation(row.item.note).toLowerCase();
+      const locationPass =
+        !locationFilter ||
+        locationText.includes(locationFilter) ||
+        (row.item.note || '').toLowerCase().includes(`在${locationFilter}`);
       const notePass = !noteFilter || (row.item.note || '').toLowerCase().includes(noteFilter);
-      const amountPass = !hasAmountMin || row.item.amount >= amountMin;
+      const amountPass =
+        (!hasAmountMin || row.item.amount >= amountMin) &&
+        (!hasAmountMax || row.item.amount <= amountMax);
 
       return (
         (!dateFilter || dateText.includes(dateFilter)) &&
@@ -558,12 +602,67 @@ export function TransactionsPage() {
         amountPass &&
         tagsPass &&
         merchantPass &&
+        locationPass &&
         orderNoPass &&
         merchantOrderNoPass &&
         notePass
       );
     });
   }, [mappedRows, quickFilters]);
+
+  const monthlySummary = useMemo(() => {
+    const now = new Date();
+    const monthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    return quickFilteredRows.reduce(
+      (acc, row) => {
+        if (!row.item.date.startsWith(monthKey)) return acc;
+        if (row.item.type === 'income') acc.income += row.item.amount;
+        else acc.expense += row.item.amount;
+        return acc;
+      },
+      { income: 0, expense: 0 }
+    );
+  }, [quickFilteredRows]);
+
+  const groupedRows = useMemo(() => {
+    const now = new Date();
+    const today = now.toISOString().slice(0, 10);
+    const thisWeek = getWeekRange(0);
+    const lastWeek = getWeekRange(-1);
+    const result: Record<'today' | 'thisWeek' | 'lastWeek', TransactionRowView[]> = {
+      today: [],
+      thisWeek: [],
+      lastWeek: []
+    };
+
+    quickFilteredRows.forEach((row) => {
+      const d = new Date(row.item.date);
+      const day = row.item.date.slice(0, 10);
+      if (day === today) {
+        result.today.push(row);
+      } else if (d >= thisWeek.from && d <= thisWeek.to) {
+        result.thisWeek.push(row);
+      } else if (d >= lastWeek.from && d <= lastWeek.to) {
+        result.lastWeek.push(row);
+      }
+    });
+
+    return result;
+  }, [quickFilteredRows]);
+
+  const tagCloud = useMemo(() => {
+    const freq = new Map<string, number>();
+    quickFilteredRows.forEach((row) => {
+      (row.item.tags || []).forEach((tag) => {
+        if (!tag) return;
+        freq.set(tag, (freq.get(tag) || 0) + 1);
+      });
+    });
+    return [...freq.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([tag, count]) => ({ tag, count }));
+  }, [quickFilteredRows]);
 
   const sortedRows = useMemo(() => {
     const rows = [...quickFilteredRows];
@@ -1005,8 +1104,10 @@ export function TransactionsPage() {
     quickFilters.category.trim().length > 0 ||
     quickFilters.account.trim().length > 0 ||
     quickFilters.amountMin.trim().length > 0 ||
+    quickFilters.amountMax.trim().length > 0 ||
     quickFilters.tags.trim().length > 0 ||
     quickFilters.merchant.trim().length > 0 ||
+    quickFilters.location.trim().length > 0 ||
     quickFilters.orderNo.trim().length > 0 ||
     quickFilters.merchantOrderNo.trim().length > 0 ||
     quickFilters.note.trim().length > 0;
@@ -1016,6 +1117,14 @@ export function TransactionsPage() {
     value: TransactionQuickFilters[K]
   ) => {
     setQuickFilters((prev) => ({ ...prev, [key]: value }));
+    if (key === 'merchant') {
+      const keyword = String(value || '').trim();
+      if (keyword) {
+        setSearchHistory((prev) =>
+          [keyword, ...prev.filter((item) => item !== keyword)].slice(0, 8)
+        );
+      }
+    }
     setPage(1);
   };
 
@@ -1217,6 +1326,100 @@ export function TransactionsPage() {
         style={{ display: 'none' }}
         onChange={(event) => void handleImportFile(event)}
       />
+
+      <section className="panel transaction-insight-panel">
+        <div className="transaction-monthly-summary">
+          <div>
+            <span>本月支出</span>
+            <strong>{formatCurrency(monthlySummary.expense)}</strong>
+          </div>
+          <div>
+            <span>本月收入</span>
+            <strong>{formatCurrency(monthlySummary.income)}</strong>
+          </div>
+          <div>
+            <span>本月净额</span>
+            <strong>{formatCurrency(monthlySummary.income - monthlySummary.expense)}</strong>
+          </div>
+        </div>
+
+        <div className="transaction-advanced-filters">
+          <input
+            value={quickFilters.amountMin}
+            onChange={(event) => handleQuickFilterChange('amountMin', event.target.value)}
+            placeholder="最小金额"
+            type="number"
+          />
+          <input
+            value={quickFilters.amountMax}
+            onChange={(event) => handleQuickFilterChange('amountMax', event.target.value)}
+            placeholder="最大金额"
+            type="number"
+          />
+          <input
+            value={quickFilters.merchant}
+            onChange={(event) => handleQuickFilterChange('merchant', event.target.value)}
+            placeholder="商户名"
+          />
+          <input
+            value={quickFilters.location}
+            onChange={(event) => handleQuickFilterChange('location', event.target.value)}
+            placeholder="消费地点"
+          />
+        </div>
+
+        {searchHistory.length > 0 ? (
+          <div className="transaction-search-history">
+            <span>历史搜索：</span>
+            {searchHistory.map((item) => (
+              <button
+                key={item}
+                type="button"
+                onClick={() => handleQuickFilterChange('merchant', item)}
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        {tagCloud.length > 0 ? (
+          <div className="transaction-tag-cloud">
+            {tagCloud.map((entry) => (
+              <button
+                key={entry.tag}
+                type="button"
+                onClick={() => handleQuickFilterChange('tags', entry.tag)}
+              >
+                #{entry.tag} ({entry.count})
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="transaction-group-grid">
+          {(
+            [
+              ['today', '今天'],
+              ['thisWeek', '本周'],
+              ['lastWeek', '上周']
+            ] as const
+          ).map(([key, label]) => (
+            <article key={key} className="transaction-group-card">
+              <h4>{label}</h4>
+              <small>{groupedRows[key].length} 笔</small>
+              <ul>
+                {groupedRows[key].slice(0, 4).map((row) => (
+                  <li key={row.item.id}>
+                    <span>{row.item.note || row.categoryName}</span>
+                    <strong>{formatCurrency(row.item.amount)}</strong>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
 
       <TransactionTable
         pageSize={pageSize}


### PR DESCRIPTION
### Motivation

- 提升交易流水页的可扫读性，按时间分组并在顶部提供本月收支摘要，帮助用户快速把握近期账务。  
- 增强检索能力，支持组合筛选（金额区间、商户、消费地点等）与快速筛选入口以加速查找。  
- 在录入/编辑场景引入 AI 建议以自动识别商户与分类，减少手动标注成本并提升分类一致性。

### Description

- 在 `TransactionsPage` 中新增顶部月度摘要与分组模块（今天/本周/上周）、标签云与历史搜索、并添加对应样式（`src/pages/transactions/TransactionsPage.tsx`、`src/app/styles/global.css`）。
- 扩展 `TransactionQuickFilters` 增加 `location` 字段并在表格筛选中支持 `amountMin`/`amountMax` 双向区间、`merchant` 和 `location` 筛选（从备注解析位置），并修正金额筛选逻辑以同时支持上下界。  
- 实现搜索历史持久化（`localStorage` 键 `ledgerflow.transactions.searchHistory`）与标签云快速回填、以及按分组展示的聚合计算与数据截取。  
- 在交易编辑页加入“AI 识别商户与分类”按钮，使用现有 `sendAiChat` 接口与 AI 设置（`useAiSettings`）调用模型解析备注并展示 JSON 建议，支持一键将建议写回备注或匹配分类（`src/pages/transaction-edit/TransactionEditPage.tsx`）。
- 修改 `TransactionTable` 以加入 `location` 类型声明与筛选输入行为调整，并同步更新相关测试默认数据（`src/features/transactions/components/TransactionTable.tsx`、`src/features/transactions/components/TransactionTable.test.tsx`）。

### Testing

- 运行构建验证：`npm run build`，构建成功（Vite 打包通过）。  
- 单元测试：`npm run test -- TransactionTable.test.tsx`，相关表格测试文件全部通过（3 个测试用例通过）。  
- 另外本地启动开发服务并生成交易页面截图用于视觉检查（dev server 可在 `http://localhost:4173/` 访问）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ba58e9a883289d9a965dd55c4750)