### PR TITLE
Optimize performance, accessibility and PWA offline sync

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom';
 import { router } from './router/router';
 import { useAppPreferences } from '../shared/store/useAppPreferences';
 import { useResolvedTheme } from '../shared/hooks/useResolvedTheme';
+import { initOfflineSyncQueue } from '../shared/lib/dataSync';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,6 +17,7 @@ const queryClient = new QueryClient({
 
 export function App() {
   const theme = useAppPreferences((s) => s.theme);
+  const highContrast = useAppPreferences((s) => s.highContrast);
   const resolvedTheme = useResolvedTheme(theme);
 
   /**
@@ -25,6 +27,14 @@ export function App() {
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', resolvedTheme);
   }, [resolvedTheme]);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-contrast', highContrast ? 'high' : 'normal');
+  }, [highContrast]);
+
+  useEffect(() => {
+    initOfflineSyncQueue();
+  }, []);
 
   return (
     <div className="app-shell">

--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -7064,3 +7064,55 @@ body.exchange-resizing {
   border-radius: 10px;
   padding: 10px;
 }
+
+:focus-visible {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.exchange-virtual-table {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.exchange-table-head,
+.exchange-table-row {
+  display: grid;
+  grid-template-columns: 48px 1.2fr 1.4fr 1fr;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+}
+
+.exchange-table-head {
+  height: 42px;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.exchange-table-body {
+  overflow-y: auto;
+  position: relative;
+}
+
+.exchange-table-row {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.exchange-table-row:hover {
+  background: var(--color-bg-hover);
+}
+
+.exchange-empty {
+  padding: var(--space-4);
+  text-align: center;
+  color: var(--color-text-secondary);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+}

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -134,3 +134,35 @@
   --shadow-xl: 0 12px 36px rgba(0, 0, 0, 0.4);
   --shadow-dropdown: 0 6px 20px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
+
+[data-contrast='high'] {
+  --color-bg: #ffffff;
+  --color-bg-elevated: #ffffff;
+  --color-bg-subtle: #f7f7f7;
+  --color-bg-hover: #ededed;
+  --color-text: #000000;
+  --color-text-secondary: #1f1f1f;
+  --color-text-tertiary: #333333;
+  --color-border: #111111;
+  --color-divider: #111111;
+  --color-primary: #0037ff;
+  --color-primary-border: #001d99;
+  --color-income: #006b1e;
+  --color-expense: #8b0000;
+}
+
+[data-theme='dark'][data-contrast='high'] {
+  --color-bg: #000000;
+  --color-bg-elevated: #000000;
+  --color-bg-subtle: #0f0f0f;
+  --color-bg-hover: #1d1d1d;
+  --color-text: #ffffff;
+  --color-text-secondary: #f0f0f0;
+  --color-text-tertiary: #d9d9d9;
+  --color-border: #f8f8f8;
+  --color-divider: #f8f8f8;
+  --color-primary: #7aa2ff;
+  --color-primary-border: #b9ccff;
+  --color-income: #67ff95;
+  --color-expense: #ff9d9d;
+}

--- a/src/features/exchange/ui/ExchangeRateTable.tsx
+++ b/src/features/exchange/ui/ExchangeRateTable.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ExchangeRate } from '../model/types';
 import { getCurrencyFlag, getCurrencyName } from '../model/types';
+import { TableSkeleton } from '../../../shared/ui/TableSkeleton';
 
 interface ExchangeRateTableProps {
   rates: ExchangeRate[];
@@ -12,7 +13,9 @@ interface ExchangeRateTableProps {
   onRefresh: () => void;
 }
 
-const PAGE_SIZE = 20;
+const ROW_HEIGHT = 46;
+const VIEWPORT_HEIGHT = 420;
+const OVERSCAN = 6;
 
 const TREND_ICON: Record<NonNullable<ExchangeRate['trend']>, string> = {
   up: '⬆️',
@@ -43,7 +46,7 @@ export function ExchangeRateTable({
       return [];
     }
   });
-  const [page, setPage] = useState(1);
+  const [scrollTop, setScrollTop] = useState(0);
 
   const toggleFavorite = (code: string) => {
     setFavorites((prev) => {
@@ -58,7 +61,6 @@ export function ExchangeRateTable({
     (r) => r.code.toLowerCase().includes(keyword) || r.name.toLowerCase().includes(keyword)
   );
 
-  // 收藏置顶
   const sorted = [...filtered].sort((a, b) => {
     const aFav = favorites.includes(a.code) ? 0 : 1;
     const bFav = favorites.includes(b.code) ? 0 : 1;
@@ -66,104 +68,99 @@ export function ExchangeRateTable({
     return a.code.localeCompare(b.code);
   });
 
-  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
-  const safePage = Math.min(page, totalPages);
-  const pageRows = sorted.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+  const totalHeight = sorted.length * ROW_HEIGHT;
+  const start = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
+  const end = Math.min(
+    sorted.length,
+    Math.ceil((scrollTop + VIEWPORT_HEIGHT) / ROW_HEIGHT) + OVERSCAN
+  );
+  const visibleRows = useMemo(() => sorted.slice(start, end), [end, sorted, start]);
 
   return (
     <div>
-      {/* 工具栏 */}
       <div className="exchange-toolbar">
         <input
           className="exchange-search"
           placeholder="搜索货币代码或名称…"
           value={search}
-          onChange={(e) => {
-            setSearch(e.target.value);
-            setPage(1);
-          }}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="搜索货币"
         />
         <span className="exchange-meta">
           基准: {getCurrencyFlag(base)} {base} ({getCurrencyName(base)}){date ? ` · ${date}` : ''}
           {fromCache ? ' · 📦 缓存' : ''}
         </span>
-        <button onClick={onRefresh} disabled={loading} title="刷新汇率">
+        <button onClick={onRefresh} disabled={loading} title="刷新汇率" aria-label="刷新汇率">
           🔄 {loading ? '加载中…' : '刷新'}
         </button>
       </div>
 
-      {/* 错误提示 */}
       {error && (
         <div className="exchange-error">
           ⚠️ {error}
-          <button onClick={onRefresh} style={{ marginLeft: 8 }}>
+          <button onClick={onRefresh} style={{ marginLeft: 8 }} aria-label="重试刷新汇率">
             重试
           </button>
         </div>
       )}
 
-      {/* 表格 */}
-      <table className="exchange-table">
-        <thead>
-          <tr>
-            <th style={{ width: 40 }}>⭐</th>
-            <th>货币</th>
-            <th>货币名称</th>
-            <th style={{ textAlign: 'right' }}>汇率 (1 {base})</th>
-          </tr>
-        </thead>
-        <tbody>
-          {pageRows.length === 0 ? (
-            <tr>
-              <td
-                colSpan={4}
-                style={{ textAlign: 'center', padding: 24, color: 'var(--color-text-tertiary)' }}
-              >
-                {loading ? '加载中…' : '无匹配货币'}
-              </td>
-            </tr>
-          ) : (
-            pageRows.map((r) => (
-              <tr key={r.code} className={favorites.includes(r.code) ? 'exchange-row-fav' : ''}>
-                <td>
-                  <button
-                    className="exchange-fav-btn"
-                    onClick={() => toggleFavorite(r.code)}
-                    title={favorites.includes(r.code) ? '取消收藏' : '收藏'}
+      {loading ? (
+        <TableSkeleton rows={8} columns={4} />
+      ) : sorted.length === 0 ? (
+        <div className="exchange-empty">无匹配货币</div>
+      ) : (
+        <div className="exchange-virtual-table">
+          <div className="exchange-table-head" role="row">
+            <span>⭐</span>
+            <span>货币</span>
+            <span>货币名称</span>
+            <span style={{ textAlign: 'right' }}>汇率 (1 {base})</span>
+          </div>
+          <div
+            className="exchange-table-body"
+            style={{ height: VIEWPORT_HEIGHT }}
+            onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+            role="list"
+            aria-label="汇率列表"
+            tabIndex={0}
+          >
+            <div style={{ height: totalHeight, position: 'relative' }}>
+              {visibleRows.map((r, index) => {
+                const rowIndex = start + index;
+                const top = rowIndex * ROW_HEIGHT;
+                const fav = favorites.includes(r.code);
+                return (
+                  <div
+                    key={r.code}
+                    className={`exchange-table-row ${fav ? 'exchange-row-fav' : ''}`}
+                    style={{ top, height: ROW_HEIGHT }}
+                    role="listitem"
                   >
-                    {favorites.includes(r.code) ? '⭐' : '☆'}
-                  </button>
-                </td>
-                <td className="mono-inline">
-                  {getCurrencyFlag(r.code)} {r.code}
-                </td>
-                <td>{r.name}</td>
-                <td style={{ textAlign: 'right' }} className="mono-inline">
-                  <span>{r.rate.toFixed(r.rate < 1 ? 6 : 4)}</span>
-                  {r.trend ? (
-                    <span className={`exchange-rate-trend exchange-rate-trend-${r.trend}`}>
-                      {TREND_ICON[r.trend]} {TREND_LABEL[r.trend]}
+                    <button
+                      className="exchange-fav-btn"
+                      onClick={() => toggleFavorite(r.code)}
+                      title={fav ? '取消收藏' : '收藏'}
+                      aria-label={`${fav ? '取消收藏' : '收藏'} ${r.code}`}
+                    >
+                      {fav ? '⭐' : '☆'}
+                    </button>
+                    <span className="mono-inline">
+                      {getCurrencyFlag(r.code)} {r.code}
                     </span>
-                  ) : null}
-                </td>
-              </tr>
-            ))
-          )}
-        </tbody>
-      </table>
-
-      {/* 分页 */}
-      {totalPages > 1 && (
-        <div className="exchange-pagination">
-          <button disabled={safePage <= 1} onClick={() => setPage(safePage - 1)}>
-            上一页
-          </button>
-          <span>
-            {safePage} / {totalPages}
-          </span>
-          <button disabled={safePage >= totalPages} onClick={() => setPage(safePage + 1)}>
-            下一页
-          </button>
+                    <span>{r.name}</span>
+                    <span style={{ textAlign: 'right' }} className="mono-inline">
+                      <span>{r.rate.toFixed(r.rate < 1 ? 6 : 4)}</span>
+                      {r.trend ? (
+                        <span className={`exchange-rate-trend exchange-rate-trend-${r.trend}`}>
+                          {TREND_ICON[r.trend]} {TREND_LABEL[r.trend]}
+                        </span>
+                      ) : null}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/features/theme-switcher/ThemeSwitcher.tsx
+++ b/src/features/theme-switcher/ThemeSwitcher.tsx
@@ -11,21 +11,34 @@ const OPTIONS: Array<{ value: AppTheme; icon: string; label: string }> = [
 export function ThemeSwitcher() {
   const theme = useAppPreferences((s) => s.theme);
   const setTheme = useAppPreferences((s) => s.setTheme);
+  const highContrast = useAppPreferences((s) => s.highContrast);
+  const setHighContrast = useAppPreferences((s) => s.setHighContrast);
 
   return (
-    <div className="theme-switcher" aria-label="主题切换">
-      {OPTIONS.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          className={theme === option.value ? 'theme-icon-btn active' : 'theme-icon-btn'}
-          onClick={() => setTheme(option.value)}
-          title={option.label}
-          aria-label={option.label}
-        >
-          <span>{option.icon}</span>
-        </button>
-      ))}
+    <div className="theme-switcher-wrap">
+      <div className="theme-switcher" aria-label="主题切换">
+        {OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            className={theme === option.value ? 'theme-icon-btn active' : 'theme-icon-btn'}
+            onClick={() => setTheme(option.value)}
+            title={option.label}
+            aria-label={option.label}
+          >
+            <span>{option.icon}</span>
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        className={highContrast ? 'theme-contrast-btn active' : 'theme-contrast-btn'}
+        onClick={() => setHighContrast(!highContrast)}
+        aria-label={highContrast ? '关闭高对比模式' : '开启高对比模式'}
+        title={highContrast ? '关闭高对比模式' : '开启高对比模式'}
+      >
+        高对比
+      </button>
     </div>
   );
 }

--- a/src/features/theme-switcher/theme-switcher.css
+++ b/src/features/theme-switcher/theme-switcher.css
@@ -1,3 +1,9 @@
+.theme-switcher-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .theme-switcher {
   display: inline-flex;
   gap: 4px;
@@ -25,9 +31,20 @@
   background: var(--color-bg-hover);
 }
 
-.theme-icon-btn.active {
+.theme-icon-btn.active,
+.theme-contrast-btn.active {
   border-color: var(--color-primary-border);
   background: var(--color-primary);
   color: #fff;
   box-shadow: var(--shadow-xs);
+}
+
+.theme-contrast-btn {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  height: 30px;
+  padding: 0 10px;
+  background: var(--color-bg-elevated);
+  color: var(--color-text);
+  cursor: pointer;
 }

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -201,9 +201,9 @@ export function DashboardPage() {
   );
   const [draggingModule, setDraggingModule] = useState<DashboardModuleId | null>(null);
 
-  const now = new Date();
-  const currentMonth = now.getMonth();
-  const currentYear = now.getFullYear();
+  const todayDay = new Date().getDate();
+  const currentMonth = new Date().getMonth();
+  const currentYear = new Date().getFullYear();
   const monthly = transactions.filter((t) => {
     const d = new Date(t.date);
     return d.getMonth() === currentMonth && d.getFullYear() === currentYear;
@@ -842,7 +842,7 @@ export function DashboardPage() {
       }));
     }
 
-    const nowPoint = new Date(currentYear, currentMonth, now.getDate());
+    const nowPoint = new Date(currentYear, currentMonth, todayDay);
     return Array.from({ length: 8 }).map((_, index) => {
       const offset = 7 - index;
       const end = new Date(nowPoint);
@@ -865,7 +865,7 @@ export function DashboardPage() {
         expense: weekExpense
       };
     });
-  }, [currentMonth, currentYear, now, recentMonths, transactions, trendGranularity]);
+  }, [currentMonth, currentYear, recentMonths, todayDay, transactions, trendGranularity]);
 
   const categoryExpensePie = useMemo(() => {
     const map = new Map<string, number>();

--- a/src/pages/finance/FinancePage.tsx
+++ b/src/pages/finance/FinancePage.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { LoadingSkeleton } from '../../shared/ui/LoadingSkeleton';
 import { useAppPreferences } from '../../shared/store/useAppPreferences';
 
 type FinanceNewsItem = {
@@ -10,7 +11,15 @@ type FinanceNewsItem = {
   summary?: string;
 };
 
-const FINANCE_NEWS_CACHE_KEY = 'ledgerflow.finance.news-cache.v1';
+type NewsCachePayload = {
+  updatedAt: string;
+  items: FinanceNewsItem[];
+};
+
+const FINANCE_NEWS_CACHE_KEY = 'ledgerflow.finance.news-cache.v2';
+const AUTO_REFRESH_INTERVAL_MS = 1000 * 60 * 15;
+const NEWS_ROW_HEIGHT = 92;
+const NEWS_VIEWPORT_HEIGHT = 420;
 
 const FINANCE_IDEAS = [
   '📌 每周固定 10 分钟复盘：本周最值得关注的 3 条财经事件是什么？',
@@ -98,36 +107,38 @@ async function fetchRssFeed(feedUrl: string, signal: AbortSignal): Promise<Finan
   return parseRssItems(xmlText, feedUrl);
 }
 
+function readNewsCache(): NewsCachePayload | null {
+  try {
+    const raw = window.localStorage.getItem(FINANCE_NEWS_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as NewsCachePayload;
+    if (!Array.isArray(parsed.items)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 export function FinancePage() {
   const { rssSubscriptions, addRssSubscription, removeRssSubscription, toggleRssSubscription } =
     useAppPreferences();
-  const [news, setNews] = useState<FinanceNewsItem[]>(() => {
-    if (typeof window === 'undefined') return [];
-    const cachedRaw = window.localStorage.getItem(FINANCE_NEWS_CACHE_KEY);
-    if (!cachedRaw) return [];
-
-    try {
-      const parsed = JSON.parse(cachedRaw) as FinanceNewsItem[];
-      return Array.isArray(parsed) && parsed.length > 0 ? parsed : [];
-    } catch {
-      return [];
-    }
-  });
-  const [loading, setLoading] = useState(true);
+  const cached = typeof window === 'undefined' ? null : readNewsCache();
+  const [news, setNews] = useState<FinanceNewsItem[]>(cached?.items || []);
+  const [loading, setLoading] = useState(!cached);
   const [error, setError] = useState('');
   const [feedTitle, setFeedTitle] = useState('');
   const [feedUrl, setFeedUrl] = useState('');
   const [activeNewsId, setActiveNewsId] = useState('');
+  const [scrollTop, setScrollTop] = useState(0);
 
   const enabledFeeds = useMemo(
     () => rssSubscriptions.filter((item) => item.enabled),
     [rssSubscriptions]
   );
 
-  useEffect(() => {
-    const controller = new AbortController();
-
-    async function loadFinanceNews() {
+  const loadFinanceNews = useCallback(
+    async (forceRefresh: boolean) => {
+      const controller = new AbortController();
       setLoading(true);
       setError('');
 
@@ -137,12 +148,13 @@ export function FinancePage() {
       }
 
       try {
+        const feedsToLoad = forceRefresh ? enabledFeeds : enabledFeeds.slice(0, 1);
         const loadedLists = await Promise.allSettled(
-          enabledFeeds.map((item) => fetchRssFeed(item.url, controller.signal))
+          feedsToLoad.map((item) => fetchRssFeed(item.url, controller.signal))
         );
         const merged = loadedLists
           .flatMap((result) => (result.status === 'fulfilled' ? result.value : []))
-          .slice(0, 20);
+          .slice(0, 80);
 
         const sorted = [...merged].sort((a, b) => {
           const aTime = Date.parse(a.publishedAt);
@@ -153,14 +165,13 @@ export function FinancePage() {
 
         if (sorted.length > 0) {
           setNews(sorted);
-          window.localStorage.setItem(FINANCE_NEWS_CACHE_KEY, JSON.stringify(sorted));
+          window.localStorage.setItem(
+            FINANCE_NEWS_CACHE_KEY,
+            JSON.stringify({ items: sorted, updatedAt: new Date().toISOString() })
+          );
           setActiveNewsId((current) => current || sorted[0].id);
         } else {
           setError('订阅源暂无可读内容，已展示上次缓存资讯。');
-        }
-
-        if (loadedLists.every((result) => result.status === 'rejected')) {
-          setError('RSS 订阅源暂不可用，已展示上次缓存资讯。');
         }
       } catch (err) {
         if ((err as Error).name !== 'AbortError') {
@@ -169,11 +180,24 @@ export function FinancePage() {
       } finally {
         setLoading(false);
       }
-    }
 
-    loadFinanceNews();
-    return () => controller.abort();
-  }, [enabledFeeds]);
+      return () => controller.abort();
+    },
+    [enabledFeeds]
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const cache = readNewsCache();
+    const isFresh =
+      cache?.updatedAt &&
+      Date.now() - new Date(cache.updatedAt).getTime() < AUTO_REFRESH_INTERVAL_MS;
+    if (!isFresh) {
+      void loadFinanceNews(false);
+    } else {
+      setLoading(false);
+    }
+  }, [loadFinanceNews]);
 
   const dailyIdea = useMemo(() => {
     const day = new Date().getDate();
@@ -184,6 +208,13 @@ export function FinancePage() {
     () => news.find((item) => item.id === activeNewsId) || news[0] || null,
     [activeNewsId, news]
   );
+
+  const virtualStart = Math.max(0, Math.floor(scrollTop / NEWS_ROW_HEIGHT) - 4);
+  const virtualEnd = Math.min(
+    news.length,
+    virtualStart + Math.ceil(NEWS_VIEWPORT_HEIGHT / NEWS_ROW_HEIGHT) + 8
+  );
+  const visibleNews = news.slice(virtualStart, virtualEnd);
 
   function onAddFeed(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -200,7 +231,10 @@ export function FinancePage() {
     <div className="page-stack finance-page">
       <section className="card">
         <h2 style={{ marginTop: 0 }}>📰 金融资讯</h2>
-        <p className="muted">支持 RSS 订阅与阅读，便于按自己的信息源持续跟踪财经动态。</p>
+        <p className="muted">减少首次请求：优先读取缓存，仅在必要时拉取订阅源。</p>
+        <button type="button" onClick={() => void loadFinanceNews(true)} aria-label="刷新财经资讯">
+          手动刷新资讯
+        </button>
 
         <details className="card" style={{ padding: 12, marginBottom: 12 }}>
           <summary style={{ cursor: 'pointer', fontWeight: 600 }}>
@@ -213,13 +247,17 @@ export function FinancePage() {
                 value={feedTitle}
                 onChange={(event) => setFeedTitle(event.target.value)}
                 placeholder="订阅名称（可选）"
+                aria-label="订阅名称"
               />
               <input
                 value={feedUrl}
                 onChange={(event) => setFeedUrl(event.target.value)}
                 placeholder="https://example.com/feed.xml"
+                aria-label="订阅地址"
               />
-              <button type="submit">新增</button>
+              <button type="submit" aria-label="新增 RSS 订阅">
+                新增
+              </button>
             </form>
 
             <div
@@ -261,10 +299,18 @@ export function FinancePage() {
                     </p>
                   </div>
                   <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
-                    <button type="button" onClick={() => toggleRssSubscription(item.id)}>
+                    <button
+                      type="button"
+                      onClick={() => toggleRssSubscription(item.id)}
+                      aria-label={`${item.enabled ? '停用' : '启用'} ${item.title}`}
+                    >
                       {item.enabled ? '停用' : '启用'}
                     </button>
-                    <button type="button" onClick={() => removeRssSubscription(item.id)}>
+                    <button
+                      type="button"
+                      onClick={() => removeRssSubscription(item.id)}
+                      aria-label={`删除订阅 ${item.title}`}
+                    >
                       删除
                     </button>
                   </div>
@@ -274,35 +320,55 @@ export function FinancePage() {
           </div>
         </details>
 
-        {loading ? <p className="muted">正在加载 RSS 资讯...</p> : null}
+        {loading ? <LoadingSkeleton lines={6} /> : null}
         {error ? <p className="muted">{error}</p> : null}
 
         {news.length === 0 ? (
           <p className="muted">暂无可展示的 RSS 缓存资讯，请检查订阅源后重试。</p>
         ) : (
-          <div style={{ display: 'grid', gap: 10 }}>
-            {news.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className="card"
-                onClick={() => setActiveNewsId(item.id)}
-                style={{
-                  padding: 12,
-                  textAlign: 'left',
-                  border:
-                    activeNews?.id === item.id
-                      ? '1px solid var(--color-primary, #2563eb)'
-                      : '1px solid var(--color-border)',
-                  background: 'transparent'
-                }}
-              >
-                <strong>{item.title}</strong>
-                <p className="muted" style={{ marginBottom: 0 }}>
-                  {item.source} · {item.publishedAt}
-                </p>
-              </button>
-            ))}
+          <div
+            style={{ height: NEWS_VIEWPORT_HEIGHT, overflowY: 'auto', position: 'relative' }}
+            onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+          >
+            <div style={{ height: news.length * NEWS_ROW_HEIGHT, position: 'relative' }}>
+              {visibleNews.map((item, index) => {
+                const rowIndex = virtualStart + index;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className="card"
+                    onClick={() => setActiveNewsId(item.id)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'ArrowDown' && news[rowIndex + 1])
+                        setActiveNewsId(news[rowIndex + 1].id);
+                      if (event.key === 'ArrowUp' && news[rowIndex - 1])
+                        setActiveNewsId(news[rowIndex - 1].id);
+                    }}
+                    style={{
+                      position: 'absolute',
+                      top: rowIndex * NEWS_ROW_HEIGHT,
+                      left: 0,
+                      right: 0,
+                      height: NEWS_ROW_HEIGHT - 6,
+                      padding: 12,
+                      textAlign: 'left',
+                      border:
+                        activeNews?.id === item.id
+                          ? '1px solid var(--color-primary, #2563eb)'
+                          : '1px solid var(--color-border)',
+                      background: 'transparent'
+                    }}
+                    aria-label={`查看资讯 ${item.title}`}
+                  >
+                    <strong>{item.title}</strong>
+                    <p className="muted" style={{ marginBottom: 0 }}>
+                      {item.source} · {item.publishedAt}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         )}
       </section>

--- a/src/shared/lib/dataSync.ts
+++ b/src/shared/lib/dataSync.ts
@@ -1,6 +1,65 @@
-import { SyncChangeRequest } from '../api/syncClient';
+import { postSyncChange, SyncChangeRequest } from '../api/syncClient';
 
 export type SyncDbType = 'redis';
+
+type QueuedSyncChange = Omit<SyncChangeRequest, 'happenedAt'> & {
+  happenedAt: string;
+  queuedAt: string;
+};
+
+const OFFLINE_QUEUE_KEY = 'ledgerflow.sync.offline-queue.v1';
+let syncInitialized = false;
+let flushing = false;
+
+function readQueue(): QueuedSyncChange[] {
+  try {
+    const raw = localStorage.getItem(OFFLINE_QUEUE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as QueuedSyncChange[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeQueue(queue: QueuedSyncChange[]) {
+  localStorage.setItem(OFFLINE_QUEUE_KEY, JSON.stringify(queue.slice(-200)));
+}
+
+async function flushSyncQueue() {
+  if (flushing || !navigator.onLine) return;
+  const queue = readQueue();
+  if (queue.length === 0) return;
+  flushing = true;
+  try {
+    const pending: QueuedSyncChange[] = [];
+    for (const item of queue) {
+      try {
+        await postSyncChange({
+          entity: item.entity,
+          action: item.action,
+          row: item.row,
+          id: item.id,
+          happenedAt: item.happenedAt
+        });
+      } catch {
+        pending.push(item);
+      }
+    }
+    writeQueue(pending);
+  } finally {
+    flushing = false;
+  }
+}
+
+export function initOfflineSyncQueue() {
+  if (syncInitialized || typeof window === 'undefined') return;
+  syncInitialized = true;
+  window.addEventListener('online', () => {
+    void flushSyncQueue();
+  });
+  void flushSyncQueue();
+}
 
 export function hasEnabledSqlConnection() {
   return false;
@@ -11,6 +70,24 @@ export function resolveSyncTargetDbType(): SyncDbType | null {
 }
 
 export async function syncChangeIfNeeded(payload: Omit<SyncChangeRequest, 'happenedAt'>) {
-  void payload;
-  return;
+  const row: QueuedSyncChange = {
+    ...payload,
+    happenedAt: new Date().toISOString(),
+    queuedAt: new Date().toISOString()
+  };
+
+  if (!navigator.onLine) {
+    const queue = readQueue();
+    queue.push(row);
+    writeQueue(queue);
+    return;
+  }
+
+  try {
+    await postSyncChange({ ...payload, happenedAt: row.happenedAt });
+  } catch {
+    const queue = readQueue();
+    queue.push(row);
+    writeQueue(queue);
+  }
 }

--- a/src/shared/store/useAppPreferences.ts
+++ b/src/shared/store/useAppPreferences.ts
@@ -27,10 +27,12 @@ const DEFAULT_RSS_SUBSCRIPTIONS: RssSubscription[] = [
 
 interface AppPreferencesState {
   theme: AppTheme;
+  highContrast: boolean;
   rssSubscriptions: RssSubscription[];
   debts: DebtItem[];
   monthlyIncome: number;
   setTheme: (theme: AppTheme) => void;
+  setHighContrast: (enabled: boolean) => void;
   addRssSubscription: (payload: { title: string; url: string }) => { ok: boolean; reason?: string };
   removeRssSubscription: (id: string) => void;
   toggleRssSubscription: (id: string) => void;
@@ -62,10 +64,12 @@ export const useAppPreferences = create<AppPreferencesState>()(
   persist(
     (set) => ({
       theme: 'system',
+      highContrast: false,
       rssSubscriptions: DEFAULT_RSS_SUBSCRIPTIONS,
       debts: [],
       monthlyIncome: 0,
       setTheme: (theme) => set({ theme }),
+      setHighContrast: (enabled) => set({ highContrast: enabled }),
       setMonthlyIncome: (income) => set({ monthlyIncome: Number.isFinite(income) ? income : 0 }),
       addRssSubscription: ({ title, url }) => {
         const normalizedUrl = normalizeFeedUrl(url);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,33 @@ export default defineConfig({
         ]
       },
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg}']
+        globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
+        cleanupOutdatedCaches: true,
+        navigateFallback: '/index.html',
+        runtimeCaching: [
+          {
+            urlPattern: ({ request }) => request.destination === 'document',
+            handler: 'NetworkFirst',
+            options: { cacheName: 'pages-cache', networkTimeoutSeconds: 5 }
+          },
+          {
+            urlPattern: ({ request }) =>
+              request.destination === 'script' || request.destination === 'style',
+            handler: 'StaleWhileRevalidate',
+            options: { cacheName: 'asset-cache' }
+          },
+          {
+            urlPattern: ({ url }) =>
+              url.pathname.includes('/sync-change') || url.pathname.includes('/sync-local-data'),
+            handler: 'NetworkOnly',
+            options: {
+              backgroundSync: {
+                name: 'ledgerflow-sync-queue',
+                options: { maxRetentionTime: 24 * 60 }
+              }
+            }
+          }
+        ]
       }
     })
   ]


### PR DESCRIPTION
### Motivation
- Reduce initial load cost and UI jank for large lists by using cache-first loading, skeletons and virtual scrolling. 
- Improve accessibility for low-vision and keyboard users by adding high-contrast support, visible focus styles and ARIA labels. 
- Harden offline behavior and sync reliability by adding a client-side offline-change queue and Workbox runtime caching/background-sync. 

### Description
- Implemented virtualized rendering and skeleton loading for the finance RSS list and exchange rates table and reduced initial network requests on the finance page (`src/pages/finance/FinancePage.tsx`, `src/features/exchange/ui/ExchangeRateTable.tsx`, `src/shared/ui/*`).
- Added persistent high-contrast toggle to preferences (`highContrast` / `setHighContrast` in `src/shared/store/useAppPreferences.ts`), updated `ThemeSwitcher` UI, and write `data-contrast` to `document.documentElement`; added tokens and CSS for high-contrast and `:focus-visible` styles (`src/features/theme-switcher/*`, `src/app/styles/tokens.css`, `src/app/styles/global.css`).
- Added offline sync queue and flush-on-online logic plus `initOfflineSyncQueue()` and updated `syncChangeIfNeeded()` to queue changes when offline (`src/shared/lib/dataSync.ts`), and extended the PWA Workbox config with runtime caching and background sync for sync endpoints (`vite.config.ts`).
- Small stability/cleanup changes including lint warning fix in dashboard date logic and various ARIA/keyboard improvements (multiple files). 

### Testing
- Ran `npm run lint` and the linter passed with no warnings or errors (✅).
- Built the production bundle with `npm run build` and the build completed successfully (✅).
- Started the dev server and captured visual verification screenshots for `finance` and `exchange` pages via a Playwright script, confirming virtual lists and skeletons rendered (artifacts available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993bae6baa08328b65114739f2c3037)