### PR TITLE
fix(transactions): prevent amount column from stretching by summary row

### DIFF
--- a/src/features/transactions/components/TransactionTable.test.tsx
+++ b/src/features/transactions/components/TransactionTable.test.tsx
@@ -306,7 +306,7 @@ describe('TransactionTable', () => {
 
     expect(screen.getByRole('button', { name: '第一页' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '最后一页' })).toBeInTheDocument();
-    expect(screen.getByText('汇总（当前页 2 条）')).toBeInTheDocument();
+    expect(screen.getByText(/汇总（当前页 2 条）/)).toBeInTheDocument();
     expect(screen.getByText(/金额合计 ¥250.00/)).toBeInTheDocument();
   });
 });

--- a/src/features/transactions/components/TransactionTable.tsx
+++ b/src/features/transactions/components/TransactionTable.tsx
@@ -746,36 +746,13 @@ export function TransactionTable({
               {rows.length > 0 && (
                 <tfoot>
                   <tr className="transaction-summary-row">
-                    {bulkSelectionEnabled ? (
-                      <td className="transaction-summary-label">汇总</td>
-                    ) : null}
-                    {orderedColumns
-                      .filter((column) => visibleColumns[column.key])
-                      .map((column, index) => {
-                        const isFirstVisible = index === 0;
-                        if (column.key === 'amount') {
-                          return (
-                            <td
-                              key={`summary-${column.key}`}
-                              className="transaction-summary-amount"
-                            >
-                              金额合计 {formatCurrency(pageSummary.overallTotal)} ｜ 收入{' '}
-                              {formatCurrency(pageSummary.incomeTotal)} ｜ 支出{' '}
-                              {formatCurrency(pageSummary.expenseTotal)} ｜ 净额{' '}
-                              {formatCurrency(pageSummary.netTotal)}
-                            </td>
-                          );
-                        }
-
-                        return (
-                          <td
-                            key={`summary-${column.key}`}
-                            className={isFirstVisible ? 'transaction-summary-label' : undefined}
-                          >
-                            {isFirstVisible ? `汇总（当前页 ${rows.length} 条）` : '-'}
-                          </td>
-                        );
-                      })}
+                    <td colSpan={visibleColumnCount} className="transaction-summary-amount">
+                      汇总（当前页 {rows.length} 条）｜ 金额合计{' '}
+                      {formatCurrency(pageSummary.overallTotal)} ｜ 收入{' '}
+                      {formatCurrency(pageSummary.incomeTotal)} ｜ 支出{' '}
+                      {formatCurrency(pageSummary.expenseTotal)} ｜ 净额{' '}
+                      {formatCurrency(pageSummary.netTotal)}
+                    </td>
                   </tr>
                 </tfoot>
               )}


### PR DESCRIPTION
### Motivation
- The footer summary row was rendered per-column and the long summary text ended up inside the `amount` column, causing the amount column to expand unexpectedly.
- The intention is to keep the `amount` column compact while still showing the page summary information in the table footer.

### Description
- Render the footer summary as a single `<td>` using `colSpan={visibleColumnCount}` so the summary text spans all visible columns instead of residing in the `amount` column.
- Update the summary cell content to include page counts and totals (`overallTotal`, `incomeTotal`, `expenseTotal`, `netTotal`) in the combined cell.
- Adjust the unit test in `TransactionTable.test.tsx` to use a regex matcher for the summary label so it remains robust after the footer restructuring.
- Files modified: `src/features/transactions/components/TransactionTable.tsx`, `src/features/transactions/components/TransactionTable.test.tsx`.

### Testing
- Ran the relevant unit tests with `npm run test -- src/features/transactions/components/TransactionTable.test.tsx`, and all tests passed.
- Ran `npx eslint src/features/transactions/components/TransactionTable.tsx src/features/transactions/components/TransactionTable.test.tsx`, and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993c11f02f08328b622b01b9786c017)